### PR TITLE
feat: extract Qalam icon library from isnad-graph (#4)

### DIFF
--- a/src/icons/admin-icon.tsx
+++ b/src/icons/admin-icon.tsx
@@ -1,0 +1,14 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Admin — gear with octagonal geometric accent */
+export function AdminIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      {/* Gear outer — octagonal shape for Islamic geometric feel */}
+      <path d="M12 2l2.2 1.3 2.5-.3 1.3 2.2 2.5.3.3 2.5 2.2 1.3L22 12l1.3 2.2-.3 2.5-2.2 1.3-.3 2.5-2.5.3-1.3 2.2-2.5-.3L12 22l-2.2-1.3-2.5.3-1.3-2.2-2.5-.3-.3-2.5L1 14.7 2 12 .7 9.3l.3-2.5 2.2-1.3.3-2.5 2.5-.3L7.3 2.7l2.5.3z" strokeWidth="1.2" />
+      {/* Inner circle */}
+      <circle cx="12" cy="12" r="3" />
+    </IconBase>
+  )
+}

--- a/src/icons/collections-icon.tsx
+++ b/src/icons/collections-icon.tsx
@@ -1,0 +1,25 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Collections — library/bookshelf with geometric shelf brackets */
+export function CollectionsIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      {/* Shelf */}
+      <path d="M3 21h18" />
+      <path d="M3 13h18" />
+      {/* Books on top shelf */}
+      <rect x="5" y="5" width="3" height="8" rx="0.5" />
+      <rect x="9" y="3" width="2.5" height="10" rx="0.5" />
+      <rect x="12.5" y="6" width="3" height="7" rx="0.5" />
+      <rect x="16.5" y="4" width="2.5" height="9" rx="0.5" />
+      {/* Books on bottom shelf */}
+      <rect x="5" y="14" width="4" height="7" rx="0.5" />
+      <rect x="10" y="15" width="3" height="6" rx="0.5" />
+      <rect x="14" y="14" width="3" height="7" rx="0.5" />
+      {/* Geometric bracket accents */}
+      <path d="M3 13l1-1 1 1" strokeWidth="1" opacity="0.5" />
+      <path d="M19 13l1-1 1 1" strokeWidth="1" opacity="0.5" />
+    </IconBase>
+  )
+}

--- a/src/icons/compare-icon.tsx
+++ b/src/icons/compare-icon.tsx
@@ -1,0 +1,21 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Compare — split/diff with geometric separator */
+export function CompareIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      {/* Left panel */}
+      <rect x="2" y="3" width="8" height="18" rx="1" />
+      {/* Right panel */}
+      <rect x="14" y="3" width="8" height="18" rx="1" />
+      {/* Connecting arrows */}
+      <path d="M10 8h4" />
+      <path d="M14 8l-1.5-1.5M14 8l-1.5 1.5" />
+      <path d="M14 16h-4" />
+      <path d="M10 16l1.5-1.5M10 16l1.5 1.5" />
+      {/* Diamond separator accent */}
+      <path d="M12 11l1 1-1 1-1-1z" fill="currentColor" stroke="none" opacity="0.5" />
+    </IconBase>
+  )
+}

--- a/src/icons/empty-graph-illustration.tsx
+++ b/src/icons/empty-graph-illustration.tsx
@@ -1,0 +1,36 @@
+import type { IllustrationProps } from './types'
+import { IllustrationBase } from './illustration-base'
+
+/** Empty graph — disconnected nodes with no edges */
+export function EmptyGraphIllustration(props: IllustrationProps) {
+  return (
+    <IllustrationBase {...props}>
+      {/* Scattered nodes */}
+      <circle cx="20" cy="24" r="4" opacity="0.3" />
+      <circle cx="48" cy="16" r="4" opacity="0.3" />
+      <circle cx="76" cy="28" r="4" opacity="0.3" />
+      <circle cx="28" cy="56" r="4" opacity="0.3" />
+      <circle cx="60" cy="52" r="4" opacity="0.3" />
+      <circle cx="44" cy="76" r="4" opacity="0.3" />
+      <circle cx="72" cy="68" r="4" opacity="0.3" />
+      {/* Dashed lines suggesting missing connections */}
+      <path d="M24 26l20-8" strokeDasharray="3 4" opacity="0.15" />
+      <path d="M52 18l20 8" strokeDasharray="3 4" opacity="0.15" />
+      <path d="M32 56l24-4" strokeDasharray="3 4" opacity="0.15" />
+      {/* Central question mark */}
+      <text
+        x="48"
+        y="48"
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="currentColor"
+        stroke="none"
+        fontSize="18"
+        fontFamily="var(--font-heading)"
+        opacity="0.25"
+      >
+        ?
+      </text>
+    </IllustrationBase>
+  )
+}

--- a/src/icons/empty-state.tsx
+++ b/src/icons/empty-state.tsx
@@ -1,0 +1,53 @@
+/**
+ * Empty state container — wraps an illustration with a message.
+ * Pure layout component, no styling opinions beyond centering.
+ */
+export function EmptyState({
+  illustration,
+  title,
+  description,
+}: {
+  illustration: React.ReactNode
+  title: string
+  description?: string
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 'var(--spacing-4)',
+        padding: 'var(--spacing-12) var(--spacing-6)',
+        textAlign: 'center',
+        color: 'var(--color-muted-foreground)',
+      }}
+    >
+      {illustration}
+      <h3
+        style={{
+          margin: 0,
+          fontSize: 'var(--text-lg)',
+          fontFamily: 'var(--font-heading)',
+          fontWeight: 500,
+          color: 'var(--color-foreground)',
+        }}
+      >
+        {title}
+      </h3>
+      {description && (
+        <p
+          style={{
+            margin: 0,
+            fontSize: 'var(--text-sm)',
+            maxWidth: 320,
+            lineHeight: 'var(--leading-relaxed)',
+          }}
+        >
+          {description}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/icons/geometric-border.tsx
+++ b/src/icons/geometric-border.tsx
@@ -1,0 +1,39 @@
+import type { SVGAttributes } from 'react'
+
+/**
+ * Repeating Islamic geometric border pattern.
+ * Renders as a horizontal divider with interlocking octagonal motifs.
+ * Width fills container; height is fixed at 12px.
+ */
+export function GeometricBorder({
+  className,
+  style,
+  ...props
+}: SVGAttributes<SVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 200 12"
+      preserveAspectRatio="none"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="0.8"
+      aria-hidden="true"
+      className={className}
+      style={{ width: '100%', height: 12, opacity: 0.3, ...style }}
+      {...props}
+    >
+      {/* Repeating octagonal / interlocking diamond pattern */}
+      <defs>
+        <pattern id="geo-border-pat" x="0" y="0" width="20" height="12" patternUnits="userSpaceOnUse">
+          {/* Diamond */}
+          <path d="M10 1l4 5-4 5-4-5z" />
+          {/* Connecting lines */}
+          <path d="M0 6h6M14 6h6" />
+          {/* Small accent squares at intersections */}
+          <rect x="9" y="5" width="2" height="2" fill="currentColor" opacity="0.4" transform="rotate(45 10 6)" />
+        </pattern>
+      </defs>
+      <rect width="200" height="12" fill="url(#geo-border-pat)" stroke="none" />
+    </svg>
+  )
+}

--- a/src/icons/graph-explorer-icon.tsx
+++ b/src/icons/graph-explorer-icon.tsx
@@ -1,0 +1,24 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Graph Explorer — network constellation with nodes and edges */
+export function GraphExplorerIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      {/* Central node */}
+      <circle cx="12" cy="12" r="2.5" />
+      {/* Outer nodes */}
+      <circle cx="5" cy="6" r="1.5" />
+      <circle cx="19" cy="6" r="1.5" />
+      <circle cx="5" cy="18" r="1.5" />
+      <circle cx="19" cy="18" r="1.5" />
+      {/* Edges connecting to center */}
+      <path d="M6.3 7.2L9.7 10.2" />
+      <path d="M17.7 7.2L14.3 10.2" />
+      <path d="M6.3 16.8L9.7 13.8" />
+      <path d="M17.7 16.8L14.3 13.8" />
+      {/* Cross-edges for network feel */}
+      <path d="M6.5 6h11" strokeDasharray="2 2" strokeWidth="1" opacity="0.3" />
+    </IconBase>
+  )
+}

--- a/src/icons/hadiths-icon.tsx
+++ b/src/icons/hadiths-icon.tsx
@@ -1,0 +1,18 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Hadiths — open manuscript/scroll */
+export function HadithsIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      {/* Open book body */}
+      <path d="M2 4s2-1 5-1 5 1 5 1v16s-2-1-5-1-5 1-5 1z" />
+      <path d="M12 4s2-1 5-1 5 1 5 1v16s-2-1-5-1-5 1-5 1z" />
+      {/* Spine */}
+      <path d="M12 4v16" />
+      {/* Text lines on left page */}
+      <path d="M5 8h3" strokeWidth="1" opacity="0.5" />
+      <path d="M5 11h3" strokeWidth="1" opacity="0.5" />
+    </IconBase>
+  )
+}

--- a/src/icons/icon-base.tsx
+++ b/src/icons/icon-base.tsx
@@ -1,0 +1,24 @@
+import type { IconProps } from './types'
+
+/**
+ * Base wrapper for 24x24 stroke-based Qalam icons.
+ * All icons use currentColor, work in light/dark mode, and are inline-friendly.
+ */
+export function IconBase({ size = 16, children, ...props }: IconProps & { children: React.ReactNode }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      {children}
+    </svg>
+  )
+}

--- a/src/icons/icons.stories.tsx
+++ b/src/icons/icons.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import {
+  NarratorsIcon,
+  HadithsIcon,
+  CollectionsIcon,
+  SearchIcon,
+  TimelineIcon,
+  CompareIcon,
+  GraphExplorerIcon,
+  AdminIcon,
+  SignOutIcon,
+  NoResultsIllustration,
+  EmptyGraphIllustration,
+  NoDataIllustration,
+  EmptyState,
+  GeometricBorder,
+  OctagonalFrame,
+  PageHeaderAccent,
+} from './index'
+import type { IconProps } from './types'
+
+const icons = [
+  { name: 'NarratorsIcon', Component: NarratorsIcon },
+  { name: 'HadithsIcon', Component: HadithsIcon },
+  { name: 'CollectionsIcon', Component: CollectionsIcon },
+  { name: 'SearchIcon', Component: SearchIcon },
+  { name: 'TimelineIcon', Component: TimelineIcon },
+  { name: 'CompareIcon', Component: CompareIcon },
+  { name: 'GraphExplorerIcon', Component: GraphExplorerIcon },
+  { name: 'AdminIcon', Component: AdminIcon },
+  { name: 'SignOutIcon', Component: SignOutIcon },
+]
+
+function IconGallery(props: IconProps) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))', gap: 24 }}>
+      {icons.map(({ name, Component }) => (
+        <div
+          key={name}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 8,
+            padding: 16,
+            borderRadius: 8,
+            border: '1px solid #e5e7eb',
+          }}
+        >
+          <Component {...props} />
+          <span style={{ fontSize: 11, color: '#6b7280', textAlign: 'center' }}>{name}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const meta: Meta = {
+  title: 'Icons/Gallery',
+}
+export default meta
+
+export const AllIcons: StoryObj = {
+  render: () => <IconGallery size={24} />,
+}
+
+export const SizeVariants: StoryObj = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
+      {[16, 24, 32, 48].map((size) => (
+        <div key={size}>
+          <h3 style={{ margin: '0 0 12px', fontSize: 14, color: '#374151' }}>Size: {size}px</h3>
+          <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
+            {icons.map(({ name, Component }) => (
+              <Component key={name} size={size} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+}
+
+export const ColorCustomization: StoryObj = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
+      {[
+        { label: 'Default (currentColor)', color: undefined },
+        { label: 'Emerald', color: '#059669' },
+        { label: 'Amber', color: '#d97706' },
+        { label: 'Rose', color: '#e11d48' },
+        { label: 'Indigo', color: '#4f46e5' },
+      ].map(({ label, color }) => (
+        <div key={label}>
+          <h3 style={{ margin: '0 0 12px', fontSize: 14, color: '#374151' }}>{label}</h3>
+          <div style={{ display: 'flex', gap: 16, alignItems: 'center', color }}>
+            {icons.map(({ name, Component }) => (
+              <Component key={name} size={24} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+}
+
+export const EmptyStateIllustrations: StoryObj = {
+  render: () => (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 32 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+        <NoResultsIllustration />
+        <span style={{ fontSize: 12, color: '#6b7280' }}>NoResultsIllustration</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+        <EmptyGraphIllustration />
+        <span style={{ fontSize: 12, color: '#6b7280' }}>EmptyGraphIllustration</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+        <NoDataIllustration />
+        <span style={{ fontSize: 12, color: '#6b7280' }}>NoDataIllustration</span>
+      </div>
+    </div>
+  ),
+}
+
+export const EmptyStateComposed: StoryObj = {
+  render: () => (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16 }}>
+      <EmptyState
+        illustration={<NoResultsIllustration />}
+        title="No results found"
+        description="Try adjusting your search terms or filters to find what you're looking for."
+      />
+      <EmptyState
+        illustration={<EmptyGraphIllustration />}
+        title="Empty graph"
+        description="No narrators or connections have been loaded yet."
+      />
+      <EmptyState
+        illustration={<NoDataIllustration />}
+        title="No data available"
+        description="This collection doesn't have any hadiths yet."
+      />
+    </div>
+  ),
+}
+
+export const DecorativeElements: StoryObj = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
+      <div>
+        <h3 style={{ margin: '0 0 12px', fontSize: 14, color: '#374151' }}>GeometricBorder</h3>
+        <GeometricBorder />
+      </div>
+      <div>
+        <h3 style={{ margin: '0 0 12px', fontSize: 14, color: '#374151' }}>OctagonalFrame</h3>
+        <div style={{ width: 100, height: 100 }}>
+          <OctagonalFrame style={{ width: '100%', height: '100%' }} />
+        </div>
+      </div>
+      <div>
+        <h3 style={{ margin: '0 0 12px', fontSize: 14, color: '#374151' }}>
+          PageHeaderAccent (inline with text)
+        </h3>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <PageHeaderAccent />
+          <span style={{ fontSize: 20, fontWeight: 600 }}>Page Title</span>
+        </div>
+      </div>
+    </div>
+  ),
+}

--- a/src/icons/illustration-base.tsx
+++ b/src/icons/illustration-base.tsx
@@ -1,0 +1,24 @@
+import type { IllustrationProps } from './types'
+
+/**
+ * Base wrapper for 96x96 empty state illustrations.
+ * Uses currentColor for automatic theme adaptation.
+ */
+export function IllustrationBase({ size = 96, children, ...props }: IllustrationProps & { children: React.ReactNode }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 96 96"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      {children}
+    </svg>
+  )
+}

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,1 +1,28 @@
-// Icon exports will be added here
+// Types
+export type { IconProps, IllustrationProps } from './types'
+
+// Base components (for custom icon creation)
+export { IconBase } from './icon-base'
+export { IllustrationBase } from './illustration-base'
+
+// Icons
+export { NarratorsIcon } from './narrators-icon'
+export { HadithsIcon } from './hadiths-icon'
+export { CollectionsIcon } from './collections-icon'
+export { SearchIcon } from './search-icon'
+export { TimelineIcon } from './timeline-icon'
+export { CompareIcon } from './compare-icon'
+export { GraphExplorerIcon } from './graph-explorer-icon'
+export { AdminIcon } from './admin-icon'
+export { SignOutIcon } from './sign-out-icon'
+
+// Empty state illustrations
+export { NoResultsIllustration } from './no-results-illustration'
+export { EmptyGraphIllustration } from './empty-graph-illustration'
+export { NoDataIllustration } from './no-data-illustration'
+export { EmptyState } from './empty-state'
+
+// Decorative elements
+export { GeometricBorder } from './geometric-border'
+export { OctagonalFrame } from './octagonal-frame'
+export { PageHeaderAccent } from './page-header-accent'

--- a/src/icons/narrators-icon.tsx
+++ b/src/icons/narrators-icon.tsx
@@ -1,0 +1,16 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Narrators — scholar/person with turban silhouette accent */
+export function NarratorsIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      {/* Head */}
+      <circle cx="12" cy="7" r="4" />
+      {/* Shoulders */}
+      <path d="M5 21v-2a7 7 0 0 1 14 0v2" />
+      {/* Small diamond accent at collar — Islamic geometric motif */}
+      <path d="M12 15l1.2 1.2L12 17.4l-1.2-1.2z" fill="currentColor" stroke="none" />
+    </IconBase>
+  )
+}

--- a/src/icons/no-data-illustration.tsx
+++ b/src/icons/no-data-illustration.tsx
@@ -1,0 +1,24 @@
+import type { IconProps } from './types'
+import { IllustrationBase } from './illustration-base'
+
+/** No data — empty scroll/manuscript */
+export function NoDataIllustration(props: IconProps) {
+  return (
+    <IllustrationBase {...props}>
+      {/* Scroll body */}
+      <rect x="20" y="14" width="56" height="62" rx="3" strokeWidth="1.5" />
+      {/* Scroll top roll */}
+      <ellipse cx="48" cy="14" rx="28" ry="4" strokeWidth="1.5" />
+      {/* Scroll bottom roll */}
+      <ellipse cx="48" cy="76" rx="28" ry="4" strokeWidth="1.5" />
+      {/* Empty text lines (ghosted) */}
+      <path d="M30 30h36" opacity="0.15" />
+      <path d="M30 38h28" opacity="0.15" />
+      <path d="M30 46h32" opacity="0.15" />
+      <path d="M30 54h24" opacity="0.15" />
+      <path d="M30 62h30" opacity="0.15" />
+      {/* Decorative diamond in center */}
+      <path d="M48 42l4 4-4 4-4-4z" fill="currentColor" opacity="0.12" stroke="none" />
+    </IllustrationBase>
+  )
+}

--- a/src/icons/no-results-illustration.tsx
+++ b/src/icons/no-results-illustration.tsx
@@ -1,0 +1,22 @@
+import type { IllustrationProps } from './types'
+import { IllustrationBase } from './illustration-base'
+
+/** No search results — magnifying glass over empty geometric pattern */
+export function NoResultsIllustration(props: IllustrationProps) {
+  return (
+    <IllustrationBase {...props}>
+      {/* Background geometric pattern (faded) */}
+      <g opacity="0.15">
+        <rect x="16" y="16" width="24" height="24" transform="rotate(45 28 28)" />
+        <rect x="48" y="16" width="24" height="24" transform="rotate(45 60 28)" />
+        <rect x="16" y="48" width="24" height="24" transform="rotate(45 28 60)" />
+        <rect x="48" y="48" width="24" height="24" transform="rotate(45 60 60)" />
+      </g>
+      {/* Magnifying glass */}
+      <circle cx="40" cy="40" r="18" strokeWidth="2" />
+      <path d="M53 53l16 16" strokeWidth="3" />
+      {/* X inside lens */}
+      <path d="M34 34l12 12M46 34l-12 12" strokeWidth="1.5" opacity="0.5" />
+    </IllustrationBase>
+  )
+}

--- a/src/icons/octagonal-frame.tsx
+++ b/src/icons/octagonal-frame.tsx
@@ -1,0 +1,34 @@
+import type { SVGAttributes } from 'react'
+
+/**
+ * Octagonal frame — wraps content (like a logo) in an octagonal border.
+ * Meant to be sized via CSS on the container.
+ */
+export function OctagonalFrame({
+  className,
+  style,
+  ...props
+}: SVGAttributes<SVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      className={className}
+      style={{ opacity: 0.5, ...style }}
+      {...props}
+    >
+      {/* Outer octagon */}
+      <polygon points="30,2 70,2 98,30 98,70 70,98 30,98 2,70 2,30" />
+      {/* Inner octagon */}
+      <polygon points="35,10 65,10 90,35 90,65 65,90 35,90 10,65 10,35" strokeDasharray="4 3" strokeWidth="1" />
+      {/* Corner accent diamonds */}
+      <path d="M15 15l3 3-3 3-3-3z" fill="currentColor" opacity="0.3" />
+      <path d="M85 15l3 3-3 3-3-3z" fill="currentColor" opacity="0.3" />
+      <path d="M15 85l3 3-3 3-3-3z" fill="currentColor" opacity="0.3" />
+      <path d="M85 85l3 3-3 3-3-3z" fill="currentColor" opacity="0.3" />
+    </svg>
+  )
+}

--- a/src/icons/page-header-accent.tsx
+++ b/src/icons/page-header-accent.tsx
@@ -1,0 +1,31 @@
+import type { SVGAttributes } from 'react'
+
+/**
+ * Page header geometric accent — small decorative element
+ * that sits beside page titles. Renders an interlocking
+ * geometric motif inspired by Islamic tilework.
+ */
+export function PageHeaderAccent({
+  className,
+  style,
+  ...props
+}: SVGAttributes<SVGElement>) {
+  return (
+    <svg
+      viewBox="-2 -2 36 28"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1"
+      aria-hidden="true"
+      className={className}
+      style={{ width: 36, height: 28, opacity: 0.35, overflow: 'visible', ...style }}
+      {...props}
+    >
+      {/* Interlocking squares forming 8-pointed star fragment */}
+      <rect x="8" y="4" width="16" height="16" rx="1" transform="rotate(0 16 12)" />
+      <rect x="8" y="4" width="16" height="16" rx="1" transform="rotate(45 16 12)" />
+      {/* Center dot */}
+      <circle cx="16" cy="12" r="1.5" fill="currentColor" stroke="none" opacity="0.5" />
+    </svg>
+  )
+}

--- a/src/icons/search-icon.tsx
+++ b/src/icons/search-icon.tsx
@@ -1,0 +1,21 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Search — magnifying glass with 4-fold star in lens */
+export function SearchIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      {/* Lens */}
+      <circle cx="11" cy="11" r="7" />
+      {/* Handle */}
+      <path d="M21 21l-4.35-4.35" />
+      {/* 4-pointed star motif inside lens */}
+      <path
+        d="M11 7l1 2.5L14.5 11l-2.5 1L11 14.5l-1-2.5L7.5 11l2.5-1z"
+        fill="currentColor"
+        stroke="none"
+        opacity="0.35"
+      />
+    </IconBase>
+  )
+}

--- a/src/icons/sign-out-icon.tsx
+++ b/src/icons/sign-out-icon.tsx
@@ -1,0 +1,13 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Sign out — door with arrow */
+export function SignOutIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </IconBase>
+  )
+}

--- a/src/icons/timeline-icon.tsx
+++ b/src/icons/timeline-icon.tsx
@@ -1,0 +1,22 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Timeline — horizontal timeline with crescent markers */
+export function TimelineIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      {/* Horizontal line */}
+      <path d="M3 12h18" />
+      {/* Timeline nodes */}
+      <circle cx="6" cy="12" r="1.5" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none" />
+      <circle cx="18" cy="12" r="1.5" fill="currentColor" stroke="none" />
+      {/* Crescent accent above center node */}
+      <path d="M10.5 7a2.5 2.5 0 0 1 3 0" />
+      <path d="M11 7.2a1.8 1.8 0 0 0 2 0" />
+      {/* Tick marks */}
+      <path d="M6 9v-2" strokeWidth="1" opacity="0.4" />
+      <path d="M18 9v-2" strokeWidth="1" opacity="0.4" />
+    </IconBase>
+  )
+}

--- a/src/icons/types.ts
+++ b/src/icons/types.ts
@@ -1,0 +1,9 @@
+import type { SVGAttributes } from 'react'
+
+export interface IconProps extends SVGAttributes<SVGElement> {
+  size?: number | string
+}
+
+export interface IllustrationProps extends SVGAttributes<SVGElement> {
+  size?: number | string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './icons'
 export * from './tokens'
 export * from './utils'


### PR DESCRIPTION
## Summary

- Extracts 9 Qalam-aesthetic SVG icons, 3 empty state illustrations, 3 decorative elements, and 1 layout component from `noorinalabs-isnad-graph` into the design system
- Each icon is individually importable for tree-shaking — importing one icon does not bundle all
- Consistent `IconProps` interface extending `React.SVGAttributes<SVGElement>` with `size?: number | string`
- All icons use `currentColor` for fill/stroke, enabling automatic theme adaptation
- Storybook stories cover: icon gallery, size variants (16/24/32/48px), color customization, empty state illustrations, composed empty states, and decorative elements

## Components

### Icons (24x24, stroke-based)
`NarratorsIcon`, `HadithsIcon`, `CollectionsIcon`, `SearchIcon`, `TimelineIcon`, `CompareIcon`, `GraphExplorerIcon`, `AdminIcon`, `SignOutIcon`

### Empty State Illustrations (96x96)
`NoResultsIllustration`, `EmptyGraphIllustration`, `NoDataIllustration`, `EmptyState` (layout wrapper)

### Decorative Elements
`GeometricBorder`, `OctagonalFrame`, `PageHeaderAccent`

## Test plan

- [x] TypeScript type checking passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Library builds successfully (`npm run build`)
- [ ] Storybook renders all icon stories correctly
- [ ] Icons render at all size variants
- [ ] Color customization works via `currentColor` inheritance

Closes #4