### PR TITLE
Add design system usage documentation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,178 @@
+# Contributing to the Qalam Design System
+
+This guide covers how to add new components, tokens, icons, and styles to `@noorinalabs/design-system`.
+
+## Prerequisites
+
+```bash
+git clone git@github.com:noorinalabs/noorinalabs-design-system.git
+cd noorinalabs-design-system
+npm install
+npm run dev  # Start Storybook
+```
+
+## Adding a Component
+
+1. **Create the component file** in `src/components/`:
+
+```tsx
+// src/components/tooltip.tsx
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import { cn } from "../utils/cn"
+
+const TooltipContent = forwardRef<
+  ElementRef<typeof TooltipPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    className={cn("rounded-md bg-popover px-3 py-1.5 text-sm shadow-md", className)}
+    {...props}
+  />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+```
+
+**Conventions:**
+- Build on **Radix UI** primitives for accessibility
+- Use **CVA** for variant definitions (not inline conditionals)
+- Use `cn()` for class merging
+- Use **CSS logical properties** (`ps-`, `pe-`, `start`, `end`) for RTL support
+- `forwardRef` all components
+- Set `displayName`
+
+2. **Add Storybook stories** in the same directory:
+
+```tsx
+// src/components/tooltip.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react'
+import { TooltipContent } from './tooltip'
+
+const meta: Meta<typeof TooltipContent> = {
+  title: 'Components/Tooltip',
+  component: TooltipContent,
+}
+export default meta
+
+type Story = StoryObj<typeof TooltipContent>
+
+export const Default: Story = {
+  // ...
+}
+```
+
+Cover all variants and states in stories.
+
+3. **Export from the barrel file**:
+
+```tsx
+// src/components/index.ts
+export { Tooltip, TooltipContent, TooltipTrigger } from './tooltip'
+```
+
+4. **Run checks**:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test
+```
+
+## Adding a Token
+
+1. **Add the CSS custom property** to the appropriate file in `src/tokens/`:
+   - Colors: `colors.css`
+   - Typography: `typography.css`
+   - Spacing/radii/z-index: `spacing.css`
+   - Shadows/motion: `shadows.css`
+
+2. **Add the TypeScript constant** to `src/tokens/index.ts`:
+
+```ts
+export const myNewToken = {
+  value: '...',
+} as const
+```
+
+Add it to the aggregate `tokens` export as well.
+
+3. **Add dark mode variants** if the token is color-related:
+   - `@media (prefers-color-scheme: dark)` block in `colors.css`
+   - `[data-theme="dark"]` override in `colors.css`
+   - `colorsDark` object in `index.ts`
+
+## Adding an Icon
+
+1. **Create the icon component** in `src/icons/`:
+
+```tsx
+// src/icons/my-icon.tsx
+import { IconBase } from './icon-base'
+import type { IconProps } from './types'
+
+export function MyIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="..." />
+    </IconBase>
+  )
+}
+```
+
+**Conventions:**
+- Use `IconBase` (24x24 viewBox, stroke-based, `currentColor`)
+- Use `IllustrationBase` for larger decorative SVGs
+- All icons are `aria-hidden="true"` by default
+- Keep path data minimal (optimize SVGs)
+
+2. **Export from the barrel file**:
+
+```tsx
+// src/icons/index.ts
+export { MyIcon } from './my-icon'
+```
+
+3. **Add a Storybook story** in `src/icons/icons.stories.tsx`.
+
+## Adding a Style
+
+1. **Add CSS classes** to the appropriate file in `src/styles/`:
+   - Layout/text utilities: `utilities.css`
+   - Component patterns: `components.css`
+   - Animations: `animations.css`
+   - Loading/empty/error states: `states.css`
+
+2. **Use design tokens** — never hardcode color values, fonts, or spacing. Always reference `var(--token-name)`.
+
+3. **Use CSS logical properties** for directional values (`margin-inline-start`, `padding-inline-end`, `text-align: start`).
+
+## Quality Checklist
+
+Before submitting a PR:
+
+- [ ] `npm run lint` passes
+- [ ] `npm run typecheck` passes
+- [ ] `npm run test` passes
+- [ ] All components have Storybook stories covering each variant
+- [ ] Components work in both LTR and RTL layouts
+- [ ] Components work in both light and dark mode
+- [ ] Tokens are exported as both CSS custom properties and TypeScript constants
+- [ ] All exports are included in barrel files (`index.ts`)
+- [ ] WCAG 2.2 AA contrast requirements met for all color combinations
+
+## Branch Naming
+
+```
+{FirstInitial}.{LastName}/{IIII}-{issue-name}
+```
+
+Example: `K.Mensah/0017-usage-documentation`
+
+## Commit Identity
+
+Use per-commit identity flags (never set global git config):
+
+```bash
+git -c user.name="Your Name" -c user.email="parametrization+Your.Name@gmail.com" commit -m "message"
+```

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -1,0 +1,103 @@
+# Getting Started with @noorinalabs/design-system
+
+The Qalam Design System provides design tokens, React components, icons, and global styles for all NoorinALabs frontends.
+
+## Installation
+
+The package is published to GitHub Packages under the `@noorinalabs` scope.
+
+### 1. Configure npm for the @noorinalabs scope
+
+Create or update `.npmrc` in your project root:
+
+```
+@noorinalabs:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+### 2. Install the package
+
+```bash
+npm install @noorinalabs/design-system
+```
+
+## Package Exports
+
+| Import Path | What You Get |
+|-------------|-------------|
+| `@noorinalabs/design-system` | All components, icons, tokens (TS), and `cn()` utility |
+| `@noorinalabs/design-system/styles` | Global CSS (tokens + styles combined) |
+| `@noorinalabs/design-system/styles.css` | Alias for the above |
+| `@noorinalabs/design-system/tokens` | TypeScript token constants only |
+| `@noorinalabs/design-system/components/*` | Individual component imports |
+
+## Setup in Your Project
+
+### React (Vite, Next.js, etc.)
+
+```tsx
+// Import global styles (tokens + utility classes) — do this once in your app entry
+import '@noorinalabs/design-system/styles.css'
+
+// Import components and icons
+import { Button, Card, CardHeader, CardTitle, CardContent } from '@noorinalabs/design-system'
+import { SearchIcon, NarratorsIcon } from '@noorinalabs/design-system'
+```
+
+### Astro
+
+```astro
+---
+// src/layouts/Layout.astro
+import '@noorinalabs/design-system/styles.css'
+---
+
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+```
+
+In Astro components that use React (via `@astrojs/react`):
+
+```astro
+---
+import { Button } from '@noorinalabs/design-system'
+---
+
+<Button client:load variant="default">Click me</Button>
+```
+
+## Dark Mode
+
+The design system supports dark mode via two mechanisms:
+
+1. **Automatic:** Respects `prefers-color-scheme: dark` media query
+2. **Manual toggle:** Set `data-theme="dark"` or `data-theme="light"` on `<html>`
+
+```tsx
+// Toggle dark mode programmatically
+document.documentElement.setAttribute('data-theme', 'dark')
+```
+
+## RTL / BiDi Support
+
+All components use CSS logical properties (`ps-`, `pe-`, `start`, `end`) instead of physical `left`/`right`. To enable RTL:
+
+```html
+<html dir="rtl" lang="ar">
+```
+
+No additional configuration is needed — components adapt automatically.
+
+## Further Reading
+
+- [Component API Reference](./components.md)
+- [Token Reference](./tokens.md)
+- [Icon Catalog](./icons.md)
+- [Global Styles & Utilities](./styles.md)
+- [Contributing Guide](../contributing.md)

--- a/docs/usage/components.md
+++ b/docs/usage/components.md
@@ -1,0 +1,357 @@
+# Component API Reference
+
+All components are built on [Radix UI](https://www.radix-ui.com/) primitives with [CVA](https://cva.style/) for variant styling. They support `className` overrides via the `cn()` utility (clsx + tailwind-merge).
+
+## Button
+
+A polymorphic button with variant and size options.
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `"default" \| "destructive" \| "outline" \| "secondary" \| "ghost" \| "link"` | `"default"` | Visual style |
+| `size` | `"default" \| "sm" \| "lg" \| "icon"` | `"default"` | Size preset |
+| `asChild` | `boolean` | `false` | Render as child element (Radix Slot) for composability |
+| `className` | `string` | — | Additional CSS classes |
+
+Plus all native `<button>` HTML attributes.
+
+### Variants
+
+- **default** — Primary background, white foreground
+- **destructive** — Red/error background
+- **outline** — Bordered, transparent background
+- **secondary** — Muted background
+- **ghost** — No background, accent on hover
+- **link** — Text-only with underline on hover
+
+### Sizes
+
+- **default** — `h-10 px-4 py-2`
+- **sm** — `h-9 px-3`
+- **lg** — `h-11 px-8`
+- **icon** — `h-10 w-10` (square, for icon-only buttons)
+
+### Examples
+
+```tsx
+import { Button } from '@noorinalabs/design-system'
+
+<Button variant="default">Save</Button>
+<Button variant="destructive" size="sm">Delete</Button>
+<Button variant="ghost" size="icon"><SearchIcon /></Button>
+
+{/* Render as a link */}
+<Button asChild variant="link">
+  <a href="/narrators">View Narrators</a>
+</Button>
+```
+
+### Exports
+
+```tsx
+import { Button, buttonVariants } from '@noorinalabs/design-system'
+import type { ButtonProps } from '@noorinalabs/design-system'
+```
+
+`buttonVariants` can be used standalone to generate class strings without the component.
+
+---
+
+## Input
+
+A text input with BiDi support using CSS logical properties.
+
+### Props
+
+All native `<input>` HTML attributes. No additional custom props.
+
+The component uses `ps-3 pe-3` (logical padding) so it works correctly in both LTR and RTL layouts. It inherits `dir` from its parent.
+
+### Example
+
+```tsx
+import { Input } from '@noorinalabs/design-system'
+
+<Input type="text" placeholder="Search narrators..." />
+<Input type="email" disabled />
+```
+
+---
+
+## Card
+
+A composable card with header, title, description, content, and footer sub-components.
+
+### Sub-components
+
+| Component | HTML Element | Purpose |
+|-----------|-------------|---------|
+| `Card` | `<div>` | Outer container with border, shadow, and background |
+| `CardHeader` | `<div>` | Top section with flex-column layout and padding |
+| `CardTitle` | `<div>` | Large semibold heading |
+| `CardDescription` | `<div>` | Muted description text |
+| `CardContent` | `<div>` | Main content area (padding, no top padding) |
+| `CardFooter` | `<div>` | Bottom section with flex row layout |
+
+All sub-components accept `className` and standard `<div>` HTML attributes.
+
+### Example
+
+```tsx
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@noorinalabs/design-system'
+import { Button } from '@noorinalabs/design-system'
+
+<Card>
+  <CardHeader>
+    <CardTitle>Narrator Profile</CardTitle>
+    <CardDescription>Abu Hurayrah (d. 59 AH)</CardDescription>
+  </CardHeader>
+  <CardContent>
+    <p>Transmitted 5,374 hadith narrations.</p>
+  </CardContent>
+  <CardFooter>
+    <Button variant="outline">View Full Profile</Button>
+  </CardFooter>
+</Card>
+```
+
+---
+
+## Badge
+
+An inline label with domain-specific variant support.
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `"default" \| "secondary" \| "destructive" \| "outline" \| "sunni" \| "shia" \| "sahih"` | `"default"` | Visual style |
+| `className` | `string` | — | Additional CSS classes |
+
+Plus all native `<div>` HTML attributes.
+
+### Domain Variants
+
+- **sunni** — Teal background, used for Sunni sect indicators
+- **shia** — Blue/indigo background, used for Shia sect indicators
+- **sahih** — Green background, used for authentic hadith grading
+
+### Example
+
+```tsx
+import { Badge } from '@noorinalabs/design-system'
+
+<Badge>Default</Badge>
+<Badge variant="sahih">Sahih</Badge>
+<Badge variant="sunni">Sunni</Badge>
+<Badge variant="destructive">Rejected</Badge>
+```
+
+### Exports
+
+```tsx
+import { Badge, badgeVariants } from '@noorinalabs/design-system'
+import type { BadgeProps } from '@noorinalabs/design-system'
+```
+
+---
+
+## Dialog
+
+A modal dialog built on Radix Dialog with overlay, animations, and close button.
+
+### Sub-components
+
+| Component | Description |
+|-----------|-------------|
+| `Dialog` | Root (manages open/close state) |
+| `DialogTrigger` | Element that opens the dialog |
+| `DialogPortal` | Portals content to document body |
+| `DialogOverlay` | Semi-transparent backdrop (`bg-black/80`) |
+| `DialogContent` | Centered modal panel with close button |
+| `DialogHeader` | Flex column header layout |
+| `DialogFooter` | Responsive footer (column on mobile, row on desktop) |
+| `DialogTitle` | Accessible title |
+| `DialogDescription` | Accessible description (muted) |
+| `DialogClose` | Close trigger |
+
+### Example
+
+```tsx
+import {
+  Dialog, DialogTrigger, DialogContent,
+  DialogHeader, DialogTitle, DialogDescription, DialogFooter
+} from '@noorinalabs/design-system'
+import { Button } from '@noorinalabs/design-system'
+
+<Dialog>
+  <DialogTrigger asChild>
+    <Button variant="outline">Edit Narrator</Button>
+  </DialogTrigger>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>Edit Narrator</DialogTitle>
+      <DialogDescription>Update the narrator's biographical details.</DialogDescription>
+    </DialogHeader>
+    {/* form fields here */}
+    <DialogFooter>
+      <Button variant="default">Save Changes</Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>
+```
+
+### BiDi Notes
+
+`DialogContent` uses `start-1/2` (not `left-1/2`) and the close button uses `end-4` for correct RTL positioning.
+
+---
+
+## Select
+
+A dropdown select built on Radix Select with check indicators and keyboard navigation.
+
+### Sub-components
+
+| Component | Description |
+|-----------|-------------|
+| `Select` | Root (manages value state) |
+| `SelectTrigger` | Button that opens the dropdown |
+| `SelectValue` | Displays selected value text |
+| `SelectContent` | Dropdown panel (portaled) |
+| `SelectGroup` | Groups related items |
+| `SelectLabel` | Non-selectable group label |
+| `SelectItem` | Selectable option with check indicator |
+| `SelectSeparator` | Visual divider between groups |
+
+### Example
+
+```tsx
+import {
+  Select, SelectTrigger, SelectValue,
+  SelectContent, SelectGroup, SelectLabel, SelectItem
+} from '@noorinalabs/design-system'
+
+<Select>
+  <SelectTrigger>
+    <SelectValue placeholder="Select a collection" />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectGroup>
+      <SelectLabel>Sunni Collections</SelectLabel>
+      <SelectItem value="bukhari">Sahih al-Bukhari</SelectItem>
+      <SelectItem value="muslim">Sahih Muslim</SelectItem>
+    </SelectGroup>
+    <SelectGroup>
+      <SelectLabel>Shia Collections</SelectLabel>
+      <SelectItem value="kafi">Al-Kafi</SelectItem>
+    </SelectGroup>
+  </SelectContent>
+</Select>
+```
+
+---
+
+## Table
+
+A data table with header, body, footer, and caption sub-components.
+
+### Sub-components
+
+| Component | HTML Element | Description |
+|-----------|-------------|-------------|
+| `Table` | `<table>` | Wrapped in overflow-auto container |
+| `TableHeader` | `<thead>` | Header row group |
+| `TableBody` | `<tbody>` | Body row group |
+| `TableFooter` | `<tfoot>` | Footer row group |
+| `TableRow` | `<tr>` | Row with hover and selected states |
+| `TableHead` | `<th>` | Header cell with logical padding |
+| `TableCell` | `<td>` | Body cell |
+| `TableCaption` | `<caption>` | Table caption (bottom) |
+
+### Example
+
+```tsx
+import {
+  Table, TableHeader, TableBody, TableRow,
+  TableHead, TableCell, TableCaption
+} from '@noorinalabs/design-system'
+
+<Table>
+  <TableCaption>Top narrators by hadith count</TableCaption>
+  <TableHeader>
+    <TableRow>
+      <TableHead>Name</TableHead>
+      <TableHead>Hadiths</TableHead>
+      <TableHead>Reliability</TableHead>
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    <TableRow>
+      <TableCell>Abu Hurayrah</TableCell>
+      <TableCell>5,374</TableCell>
+      <TableCell>Thiqah</TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
+```
+
+### BiDi Notes
+
+`TableHead` uses `text-start` and logical padding (`ps-4 pe-4`) for automatic RTL alignment.
+
+---
+
+## Tabs
+
+A tabbed interface built on Radix Tabs with keyboard navigation.
+
+### Sub-components
+
+| Component | Description |
+|-----------|-------------|
+| `Tabs` | Root (manages active tab state) |
+| `TabsList` | Container for tab triggers |
+| `TabsTrigger` | Individual tab button |
+| `TabsContent` | Content panel for each tab |
+
+### Example
+
+```tsx
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@noorinalabs/design-system'
+
+<Tabs defaultValue="narrators">
+  <TabsList>
+    <TabsTrigger value="narrators">Narrators</TabsTrigger>
+    <TabsTrigger value="hadiths">Hadiths</TabsTrigger>
+    <TabsTrigger value="graph">Graph</TabsTrigger>
+  </TabsList>
+  <TabsContent value="narrators">
+    {/* Narrator list */}
+  </TabsContent>
+  <TabsContent value="hadiths">
+    {/* Hadith list */}
+  </TabsContent>
+  <TabsContent value="graph">
+    {/* Graph explorer */}
+  </TabsContent>
+</Tabs>
+```
+
+---
+
+## Utility: `cn()`
+
+A class name merge utility combining [clsx](https://github.com/lukeed/clsx) and [tailwind-merge](https://github.com/dcastil/tailwind-merge). Use it to conditionally apply and override Tailwind classes.
+
+```tsx
+import { cn } from '@noorinalabs/design-system'
+
+<div className={cn(
+  "p-4 rounded-md",
+  isActive && "bg-primary text-primary-foreground",
+  className
+)} />
+```

--- a/docs/usage/icons.md
+++ b/docs/usage/icons.md
@@ -1,0 +1,101 @@
+# Icon Catalog
+
+The Qalam Design System provides domain-specific SVG icons as React components. All icons use `currentColor` for stroke, making them theme-aware in both light and dark mode.
+
+## Usage
+
+```tsx
+import { NarratorsIcon, SearchIcon, HadithsIcon } from '@noorinalabs/design-system'
+
+<NarratorsIcon />
+<SearchIcon size={24} />
+<HadithsIcon className="text-primary" />
+```
+
+## Icon Props
+
+All icons extend `SVGAttributes<SVGElement>` and accept:
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `size` | `number \| string` | `16` | Width and height in pixels |
+| `className` | `string` | — | Additional CSS classes |
+| `...rest` | `SVGAttributes` | — | Any valid SVG attribute |
+
+Icons are rendered with `aria-hidden="true"` by default. For interactive icons, add an accessible label:
+
+```tsx
+<button aria-label="Search">
+  <SearchIcon />
+</button>
+```
+
+## Navigation & Feature Icons
+
+| Component | Import | Description |
+|-----------|--------|-------------|
+| `NarratorsIcon` | `import { NarratorsIcon } from '@noorinalabs/design-system'` | Narrator listing pages |
+| `HadithsIcon` | `import { HadithsIcon } from '@noorinalabs/design-system'` | Hadith listing pages |
+| `CollectionsIcon` | `import { CollectionsIcon } from '@noorinalabs/design-system'` | Collection browsing |
+| `SearchIcon` | `import { SearchIcon } from '@noorinalabs/design-system'` | Search functionality |
+| `TimelineIcon` | `import { TimelineIcon } from '@noorinalabs/design-system'` | Timeline views |
+| `CompareIcon` | `import { CompareIcon } from '@noorinalabs/design-system'` | Comparison features |
+| `GraphExplorerIcon` | `import { GraphExplorerIcon } from '@noorinalabs/design-system'` | Graph explorer |
+| `AdminIcon` | `import { AdminIcon } from '@noorinalabs/design-system'` | Admin panel |
+| `SignOutIcon` | `import { SignOutIcon } from '@noorinalabs/design-system'` | Sign out action |
+
+## Empty State Illustrations
+
+Larger illustrations for zero-data states. These accept `IllustrationProps` (same shape as `IconProps`).
+
+| Component | Import | Description |
+|-----------|--------|-------------|
+| `NoResultsIllustration` | `import { NoResultsIllustration } from '@noorinalabs/design-system'` | Search returned no results |
+| `EmptyGraphIllustration` | `import { EmptyGraphIllustration } from '@noorinalabs/design-system'` | Graph has no data |
+| `NoDataIllustration` | `import { NoDataIllustration } from '@noorinalabs/design-system'` | Generic no-data state |
+| `EmptyState` | `import { EmptyState } from '@noorinalabs/design-system'` | Composed empty state with icon, heading, and body |
+
+### Example
+
+```tsx
+import { NoResultsIllustration } from '@noorinalabs/design-system'
+
+<div className="empty-state">
+  <div className="empty-state-icon">
+    <NoResultsIllustration size={64} />
+  </div>
+  <div className="empty-state-heading">No results found</div>
+  <div className="empty-state-body">Try adjusting your search terms.</div>
+</div>
+```
+
+## Decorative Elements
+
+Islamic geometric patterns for visual accents.
+
+| Component | Import | Description |
+|-----------|--------|-------------|
+| `GeometricBorder` | `import { GeometricBorder } from '@noorinalabs/design-system'` | Repeating geometric border pattern |
+| `OctagonalFrame` | `import { OctagonalFrame } from '@noorinalabs/design-system'` | Octagonal decorative frame |
+| `PageHeaderAccent` | `import { PageHeaderAccent } from '@noorinalabs/design-system'` | Accent element for page headers |
+
+## Base Components
+
+For creating custom icons that match the Qalam style:
+
+```tsx
+import { IconBase } from '@noorinalabs/design-system'
+import type { IconProps } from '@noorinalabs/design-system'
+
+function MyCustomIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M12 2L2 7l10 5 10-5-10-5z" />
+    </IconBase>
+  )
+}
+```
+
+`IconBase` renders a 24x24 viewBox SVG with `stroke="currentColor"`, `strokeWidth="1.5"`, `fill="none"`, and `aria-hidden="true"`.
+
+For illustrations, use `IllustrationBase` instead (same API, designed for larger decorative SVGs).

--- a/docs/usage/styles.md
+++ b/docs/usage/styles.md
@@ -1,0 +1,225 @@
+# Global Styles & Utilities
+
+The design system ships global CSS that provides utility classes, component patterns, animations, and state styles. These are loaded automatically when you import the stylesheet.
+
+## Loading Styles
+
+```tsx
+// Import once in your app entry point
+import '@noorinalabs/design-system/styles.css'
+```
+
+This single import loads:
+1. **Design tokens** — all CSS custom properties (colors, typography, spacing, etc.)
+2. **Tailwind CSS** — the utility framework
+3. **Utility classes** — text helpers, layout, links, Arabic/RTL support
+4. **Component classes** — tables, cards, badges, buttons, forms, pagination
+5. **Animations** — skeleton loading shimmer
+6. **State patterns** — loading, empty, and error page styles
+
+---
+
+## Utility Classes
+
+### Text Helpers
+
+| Class | Description |
+|-------|-------------|
+| `.error-text` | Destructive/error colored text |
+| `.muted-text` | Muted foreground text |
+| `.small-muted` | Small muted text (`--text-sm`) |
+| `.mono` | Monospace font at small size |
+
+### Status Text
+
+| Class | Description |
+|-------|-------------|
+| `.text-success` | Success color |
+| `.text-danger` | Destructive color |
+| `.text-warning` | Warning color |
+| `.text-active` | Success + semibold (active status) |
+| `.text-suspended` | Destructive + semibold (suspended status) |
+
+### Layout
+
+| Class | Description |
+|-------|-------------|
+| `.flex-row` | `display: flex; gap: 8px; align-items: center` |
+| `.flex-row-wrap` | `display: flex; gap: 16px; flex-wrap: wrap` |
+| `.grid-2col` | Two-column grid with 16px gap |
+| `.section` | Top margin (24px) |
+| `.section-mb` | Bottom margin (32px) |
+
+### Page Heading
+
+```html
+<h1 class="page-heading">Narrator Database</h1>
+```
+
+Uses the serif heading font with a primary-colored bottom border — the standard page title style.
+
+### Links
+
+| Class | Description |
+|-------|-------------|
+| `.link-primary` | Primary-colored link, underline on hover |
+| `.link-muted` | Muted link, turns primary on hover |
+
+---
+
+## Arabic & RTL Utilities
+
+| Class | Description |
+|-------|-------------|
+| `.text-rtl` | Sets `direction: rtl`, right-aligned, Arabic font |
+| `.text-arabic-block` | RTL block with card background, Arabic font, generous line height |
+| `.text-english-block` | LTR block with card background, relaxed line height |
+
+### Example
+
+```html
+<div class="text-arabic-block">
+  بِسْمِ اللَّهِ الرَّحْمَنِ الرَّحِيمِ
+</div>
+```
+
+---
+
+## Islamic Geometric Accents
+
+CSS-only decorative elements for section dividers.
+
+### Geometric Divider
+
+```html
+<div class="geo-divider">
+  <span class="geo-divider-diamond"></span>
+</div>
+```
+
+A horizontal line with a diamond accent in the center — uses the primary color.
+
+### Geometric Borders
+
+| Class | Description |
+|-------|-------------|
+| `.geo-border-top` | Repeating dash pattern as a top border |
+| `.geo-border-bottom` | Repeating dash pattern as a bottom border |
+
+---
+
+## Component CSS Classes
+
+These are plain CSS classes for when you need the styling without React components. The React components (Button, Card, etc.) are preferred when using React.
+
+### Data Tables
+
+```html
+<table class="data-table">
+  <thead><tr><th>Name</th><th>Count</th></tr></thead>
+  <tbody>
+    <tr class="clickable-row"><td>Abu Hurayrah</td><td>5,374</td></tr>
+  </tbody>
+</table>
+```
+
+Add `.data-table-compact` for reduced padding. Rows with `.clickable-row` get a pointer cursor and hover highlight.
+
+### Stat Cards
+
+```html
+<div class="stat-card">
+  <div class="stat-card-label">Total Narrators</div>
+  <div class="stat-card-value">12,450</div>
+</div>
+```
+
+### CSS Badges
+
+```html
+<span class="badge badge-sahih">Sahih</span>
+<span class="badge badge-sunni">Sunni</span>
+<span class="badge badge-topic">Fiqh</span>
+```
+
+Domain variants: `.badge-sunni`, `.badge-shia`, `.badge-sahih`, `.badge-other-grade`, `.badge-topic`, `.badge-approved`, `.badge-rejected`, `.badge-pending`, `.badge-narrator`, `.badge-hadith`, `.badge-collection`.
+
+### CSS Buttons
+
+| Class | Description |
+|-------|-------------|
+| `.btn` | Default secondary button |
+| `.btn-sm` | Small secondary button |
+| `.btn-primary` | Primary action button |
+| `.btn-danger` | Destructive outline button |
+| `.btn-action` | Tiny action button base |
+
+### Forms
+
+| Class | Description |
+|-------|-------------|
+| `.form-input` | Styled text input |
+| `.form-input-block` | Full-width input |
+| `.form-input-sm` | Small (80px) input |
+
+---
+
+## Animations
+
+### Skeleton Loading
+
+```html
+<div class="skeleton skeleton-heading"></div>
+<div class="skeleton skeleton-text"></div>
+<div class="skeleton skeleton-text"></div>
+<div class="skeleton skeleton-row"></div>
+```
+
+| Class | Height | Purpose |
+|-------|--------|---------|
+| `.skeleton` | — | Base class (shimmer animation) |
+| `.skeleton-text` | 1em | Body text placeholder |
+| `.skeleton-heading` | 1.5em (40% width) | Heading placeholder |
+| `.skeleton-row` | 2.5rem | Table/list row placeholder |
+
+Automatically disables animation when `prefers-reduced-motion: reduce` is active.
+
+---
+
+## State Patterns
+
+### Empty State
+
+```html
+<div class="empty-state">
+  <div class="empty-state-icon"><!-- icon here --></div>
+  <div class="empty-state-heading">No results found</div>
+  <div class="empty-state-body">Try adjusting your search filters.</div>
+</div>
+```
+
+### Error Page
+
+```html
+<div class="error-page">
+  <div class="error-page-code">404</div>
+  <div class="error-page-title">Page not found</div>
+  <div class="error-page-body">The page you requested does not exist.</div>
+</div>
+```
+
+---
+
+## Scrollbar Styling
+
+Custom scrollbar styling is applied globally:
+- 8px width/height
+- Track matches background color
+- Thumb matches border color with full rounding
+- Hover state uses muted foreground color
+
+---
+
+## Selection Styling
+
+Text selection uses the primary color as background with primary-foreground text, applied globally via `::selection`.

--- a/docs/usage/tokens.md
+++ b/docs/usage/tokens.md
@@ -1,0 +1,278 @@
+# Token Reference
+
+Design tokens are the foundational values (colors, typography, spacing, shadows, etc.) that ensure visual consistency across all NoorinALabs products. They are available as both **CSS custom properties** and **TypeScript constants**.
+
+## Importing Tokens
+
+### CSS Custom Properties
+
+Import the stylesheet once in your app entry:
+
+```tsx
+import '@noorinalabs/design-system/styles.css'
+```
+
+Then use custom properties anywhere in CSS or Tailwind:
+
+```css
+.my-element {
+  color: var(--color-primary);
+  font-family: var(--font-body);
+  padding: var(--spacing-4);
+  box-shadow: var(--shadow-md);
+}
+```
+
+### TypeScript Constants
+
+For programmatic access (charting libraries, styled-components, runtime logic):
+
+```tsx
+import { colors, fontFamily, spacing, shadow } from '@noorinalabs/design-system/tokens'
+
+// Use in a charting library
+const chartColor = colors.primary // 'oklch(0.55 0.14 45)'
+
+// Or import the aggregate object
+import { tokens } from '@noorinalabs/design-system/tokens'
+tokens.colors.sahih // 'oklch(0.55 0.10 175)'
+```
+
+---
+
+## Colors
+
+The color system uses the **OKLCH** color space for perceptually uniform palettes. All combinations meet WCAG 2.2 AA contrast requirements.
+
+### Semantic Colors
+
+| Token (CSS) | Token (TS) | Purpose |
+|-------------|-----------|---------|
+| `--color-primary` | `colors.primary` | Primary brand action color |
+| `--color-primary-hover` | `colors.primaryHover` | Primary hover state |
+| `--color-primary-foreground` | `colors.primaryForeground` | Text on primary |
+| `--color-secondary` | `colors.secondary` | Secondary actions |
+| `--color-secondary-foreground` | `colors.secondaryForeground` | Text on secondary |
+| `--color-muted` | `colors.muted` | Muted backgrounds |
+| `--color-muted-foreground` | `colors.mutedForeground` | Muted text |
+| `--color-accent` | `colors.accent` | Accent highlights |
+| `--color-accent-foreground` | `colors.accentForeground` | Text on accent |
+| `--color-destructive` | `colors.destructive` | Destructive/error actions |
+| `--color-destructive-foreground` | `colors.destructiveForeground` | Text on destructive |
+| `--color-success` | `colors.success` | Success states |
+| `--color-warning` | `colors.warning` | Warning states |
+| `--color-info` | `colors.info` | Informational states |
+
+### Surface Colors
+
+| Token (CSS) | Token (TS) | Purpose |
+|-------------|-----------|---------|
+| `--color-background` | `colors.background` | Page background |
+| `--color-foreground` | `colors.foreground` | Default text color |
+| `--color-card` | `colors.card` | Card/panel background |
+| `--color-card-foreground` | `colors.cardForeground` | Text on cards |
+| `--color-popover` | `colors.popover` | Popover/dropdown background |
+| `--color-popover-foreground` | `colors.popoverForeground` | Text on popovers |
+
+### Interactive Colors
+
+| Token (CSS) | Token (TS) | Purpose |
+|-------------|-----------|---------|
+| `--color-border` | `colors.border` | Default border color |
+| `--color-input` | `colors.input` | Input border color |
+| `--color-ring` | `colors.ring` | Focus ring color |
+
+### Domain: Hadith Grading
+
+| Token (CSS) | Token (TS) | Purpose |
+|-------------|-----------|---------|
+| `--color-sahih` / `--color-sahih-bg` | `colors.sahih` / `colors.sahihBg` | Authentic (green) |
+| `--color-hasan` / `--color-hasan-bg` | `colors.hasan` / `colors.hasanBg` | Good (amber) |
+| `--color-daif` / `--color-daif-bg` | `colors.daif` / `colors.daifBg` | Weak (red) |
+| `--color-mawdu` / `--color-mawdu-bg` | `colors.mawdu` / `colors.mawduBg` | Fabricated (dark red) |
+
+### Domain: Sect Indicators
+
+| Token (CSS) | Token (TS) | Purpose |
+|-------------|-----------|---------|
+| `--color-sunni` / `--color-sunni-bg` | `colors.sunni` / `colors.sunniBg` | Sunni (teal) |
+| `--color-shia` / `--color-shia-bg` | `colors.shia` / `colors.shiaBg` | Shia (indigo) |
+
+### Domain: Narrator Reliability Tiers
+
+| Token (CSS) | Token (TS) | Purpose |
+|-------------|-----------|---------|
+| `--color-tier-thiqah` | `colors.tierThiqah` | Trustworthy |
+| `--color-tier-saduq` | `colors.tierSaduq` | Truthful |
+| `--color-tier-daif-narrator` | `colors.tierDaifNarrator` | Weak narrator |
+| `--color-tier-matruk` | `colors.tierMatruk` | Abandoned |
+| `--color-tier-kadhdhab` | `colors.tierKadhdhab` | Liar |
+
+### Dark Mode
+
+Dark mode tokens are provided automatically via:
+- `prefers-color-scheme: dark` media query
+- `data-theme="dark"` attribute on `<html>`
+
+Dark-mode values are available in TypeScript as `colorsDark`:
+
+```tsx
+import { colorsDark } from '@noorinalabs/design-system/tokens'
+colorsDark.primary // 'oklch(0.65 0.14 45)'
+```
+
+---
+
+## Typography
+
+### Font Families
+
+| Token (CSS) | Token (TS) | Fonts | Usage |
+|-------------|-----------|-------|-------|
+| `--font-arabic` | `fontFamily.arabic` | Noto Naskh Arabic, serif | Arabic script text |
+| `--font-heading` | `fontFamily.heading` | IBM Plex Serif, Georgia, serif | Headings |
+| `--font-body` | `fontFamily.body` | IBM Plex Sans, Inter, system-ui | Body text |
+| `--font-mono` | `fontFamily.mono` | IBM Plex Mono, ui-monospace | Code blocks |
+
+### Type Scale
+
+| Token (CSS) | Token (TS) | Size |
+|-------------|-----------|------|
+| `--text-xs` | `fontSize.xs` | 0.75rem (12px) |
+| `--text-sm` | `fontSize.sm` | 0.875rem (14px) |
+| `--text-base` | `fontSize.base` | 1rem (16px) |
+| `--text-lg` | `fontSize.lg` | 1.125rem (18px) |
+| `--text-xl` | `fontSize.xl` | 1.25rem (20px) |
+| `--text-2xl` | `fontSize["2xl"]` | 1.5rem (24px) |
+| `--text-3xl` | `fontSize["3xl"]` | 1.875rem (30px) |
+| `--text-4xl` | `fontSize["4xl"]` | 2.25rem (36px) |
+
+### Line Heights
+
+| Token (CSS) | Token (TS) | Value |
+|-------------|-----------|-------|
+| `--leading-tight` | `lineHeight.tight` | 1.25 |
+| `--leading-normal` | `lineHeight.normal` | 1.5 |
+| `--leading-relaxed` | `lineHeight.relaxed` | 1.625 |
+| `--leading-loose` | `lineHeight.loose` | 2 |
+
+### Font Weights
+
+| Token (CSS) | Token (TS) | Value |
+|-------------|-----------|-------|
+| `--font-weight-normal` | `fontWeight.normal` | 400 |
+| `--font-weight-medium` | `fontWeight.medium` | 500 |
+| `--font-weight-semibold` | `fontWeight.semibold` | 600 |
+| `--font-weight-bold` | `fontWeight.bold` | 700 |
+
+### Arabic Typography
+
+| Token (CSS) | Token (TS) | Value | Purpose |
+|-------------|-----------|-------|---------|
+| `--arabic-line-height` | `arabicTypography.lineHeight` | 2 | Extra line height for Arabic diacritics |
+| `--arabic-body-size` | `arabicTypography.bodySize` | 1.125rem | Larger base size for Arabic readability |
+| `--arabic-heading-size` | `arabicTypography.headingSize` | 1.5rem | Arabic heading size |
+
+---
+
+## Spacing
+
+Based on a 4px base scale with semantic aliases.
+
+### Scale
+
+| Token (CSS) | Token (TS) | Value |
+|-------------|-----------|-------|
+| `--spacing-px` | `spacing.px` | 1px |
+| `--spacing-0` | `spacing[0]` | 0 |
+| `--spacing-0_5` | `spacing[0.5]` | 0.125rem (2px) |
+| `--spacing-1` | `spacing[1]` | 0.25rem (4px) |
+| `--spacing-1_5` | `spacing[1.5]` | 0.375rem (6px) |
+| `--spacing-2` | `spacing[2]` | 0.5rem (8px) |
+| `--spacing-3` | `spacing[3]` | 0.75rem (12px) |
+| `--spacing-4` | `spacing[4]` | 1rem (16px) |
+| `--spacing-6` | `spacing[6]` | 1.5rem (24px) |
+| `--spacing-8` | `spacing[8]` | 2rem (32px) |
+| `--spacing-12` | `spacing[12]` | 3rem (48px) |
+| `--spacing-16` | `spacing[16]` | 4rem (64px) |
+| `--spacing-20` | `spacing[20]` | 5rem (80px) |
+| `--spacing-24` | `spacing[24]` | 6rem (96px) |
+
+### Semantic Aliases
+
+| Token (CSS) | Token (TS) | Maps To |
+|-------------|-----------|---------|
+| `--spacing-xs` | `spacingSemantic.xs` | `--spacing-1` (4px) |
+| `--spacing-sm` | `spacingSemantic.sm` | `--spacing-2` (8px) |
+| `--spacing-md` | `spacingSemantic.md` | `--spacing-4` (16px) |
+| `--spacing-lg` | `spacingSemantic.lg` | `--spacing-6` (24px) |
+| `--spacing-xl` | `spacingSemantic.xl` | `--spacing-8` (32px) |
+
+---
+
+## Shadows
+
+OKLCH-based shadows with deeper dark mode variants.
+
+| Token (CSS) | Token (TS) | Usage |
+|-------------|-----------|-------|
+| `--shadow-xs` | `shadow.xs` | Subtle elevation (inputs, small cards) |
+| `--shadow-sm` | `shadow.sm` | Light elevation (cards) |
+| `--shadow-md` | `shadow.md` | Medium elevation (dropdowns) |
+| `--shadow-lg` | `shadow.lg` | High elevation (modals) |
+| `--shadow-xl` | `shadow.xl` | Highest elevation (popovers) |
+
+Dark mode shadows (TypeScript): `shadowDark.xs` through `shadowDark.xl`.
+
+---
+
+## Border Radii
+
+| Token (CSS) | Token (TS) | Value |
+|-------------|-----------|-------|
+| `--radius-sm` | `radius.sm` | 0.25rem (4px) |
+| `--radius-md` | `radius.md` | 0.375rem (6px) |
+| `--radius-lg` | `radius.lg` | 0.5rem (8px) |
+| `--radius-xl` | `radius.xl` | 0.75rem (12px) |
+| `--radius-2xl` | `radius["2xl"]` | 1rem (16px) |
+| `--radius-full` | `radius.full` | 9999px (pill) |
+
+---
+
+## Z-Index
+
+| Token (CSS) | Token (TS) | Value | Usage |
+|-------------|-----------|-------|-------|
+| `--z-base` | `zIndex.base` | 0 | Default |
+| `--z-dropdown` | `zIndex.dropdown` | 100 | Dropdown menus |
+| `--z-sticky` | `zIndex.sticky` | 200 | Sticky headers |
+| `--z-overlay` | `zIndex.overlay` | 300 | Overlays |
+| `--z-modal` | `zIndex.modal` | 400 | Modals |
+| `--z-popover` | `zIndex.popover` | 500 | Popovers |
+| `--z-toast` | `zIndex.toast` | 600 | Toast notifications |
+| `--z-tooltip` | `zIndex.tooltip` | 700 | Tooltips |
+
+---
+
+## Motion
+
+| Token (CSS) | Token (TS) | Value |
+|-------------|-----------|-------|
+| `--duration-fast` | `duration.fast` | 100ms |
+| `--duration-normal` | `duration.normal` | 200ms |
+| `--duration-slow` | `duration.slow` | 300ms |
+| `--duration-slower` | `duration.slower` | 500ms |
+| `--ease-default` | `easing.default` | cubic-bezier(0.4, 0, 0.2, 1) |
+| `--ease-in` | `easing.in` | cubic-bezier(0.4, 0, 1, 1) |
+| `--ease-out` | `easing.out` | cubic-bezier(0, 0, 0.2, 1) |
+| `--ease-in-out` | `easing.inOut` | cubic-bezier(0.4, 0, 0.2, 1) |
+
+---
+
+## Borders
+
+| Token (CSS) | Token (TS) | Value |
+|-------------|-----------|-------|
+| `--border-width-thin` | `borderWidth.thin` | 1px |
+| `--border-width-medium` | `borderWidth.medium` | 2px |
+| `--border-width-thick` | `borderWidth.thick` | 4px |


### PR DESCRIPTION
## Summary

- Create comprehensive consumer-facing documentation in `docs/usage/` covering getting started, component API reference (all 8 components), token reference, icon catalog, and global styles guide
- Add `docs/contributing.md` with instructions for adding new components, tokens, icons, and styles
- All documentation references actual source code for accurate props, variants, and exports

## Files Added

| File | Content |
|------|---------|
| `docs/usage/README.md` | Installation, setup (React + Astro), dark mode, RTL |
| `docs/usage/components.md` | API reference for Button, Input, Card, Badge, Dialog, Select, Table, Tabs + cn() utility |
| `docs/usage/tokens.md` | CSS custom properties and TypeScript constants for colors, typography, spacing, shadows, motion, borders |
| `docs/usage/icons.md` | Full icon catalog (9 nav icons, 4 illustrations, 3 decorative elements) with usage patterns |
| `docs/usage/styles.md` | Global CSS utilities, component classes, animations, state patterns, RTL/Arabic support |
| `docs/contributing.md` | How to add components, tokens, icons, styles + quality checklist |

## Test Plan

- [x] `npm run lint` — passes (0 errors)
- [x] `npm run typecheck` — passes
- [x] `npm run test` — 47 tests pass
- [ ] Review docs for accuracy against source code
- [ ] Verify all import paths and component names are correct

Closes #17

Co-Authored-By: Kofi Mensah <parametrization+Kofi.Mensah@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>