### PR TITLE
Configure GitHub Packages publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
-name: Publish
+name: Publish to GitHub Packages
 
 on:
+  release:
+    types: [published]
   push:
     tags: ['v*']
 
@@ -10,24 +12,28 @@ jobs:
 
     permissions:
       contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: npm
-          registry-url: https://registry.npmjs.org
+          registry-url: https://npm.pkg.github.com
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Check (lint + typecheck + test)
+        run: npm run check
+
       - name: Build
         run: npm run build
 
-      - name: Publish to npm
-        run: npm publish --access public
+      - name: Publish
+        run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@noorinalabs:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
     "./styles": "./dist/styles.css",
     "./styles.css": "./dist/styles.css"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/noorinalabs/noorinalabs-design-system.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "sideEffects": [
     "**/*.css"
   ],


### PR DESCRIPTION
## Summary
- Update `package.json` with `repository` URL and `publishConfig` targeting GitHub Packages (`npm.pkg.github.com`)
- Rewrite `.github/workflows/publish.yml` to publish to GitHub Packages on release/tag events, using Node 22 and running the full `npm run check` suite before publish
- Add `.npmrc` scoping `@noorinalabs` to the GitHub Packages registry
- Consumer installation instructions already documented in `docs/usage/README.md`

## Verification
- `npm run check` passes (lint + typecheck + 47 tests)
- `npm run build` produces `dist/` with `index.js`, `index.cjs`, `index.d.ts`, `styles.css`, components, tokens, icons, and utils

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)