### PR TITLE
ops: Audit .gitignore — add Playwright and Storybook cache patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,13 @@ coverage/
 .turbo/
 .eslintcache
 
+# Playwright
+playwright-report/
+test-results/
+
+# Storybook cache
+.storybook/cache/
+
 # Temporary files
 tmp/
 temp/


### PR DESCRIPTION
## Summary
- Adds missing patterns: `playwright-report/`, `test-results/`, `.storybook/cache/`
- Existing coverage was already comprehensive (logs, cache, Node, builds all covered)
- `.claude/` config remains tracked (only `.claude/projects/` is ignored, as intended)
- No tracked files required removal

Closes #33

## Reviewer
Requestor (author): Santiago Ferreira
Requestee (reviewer): Aino Virtanen

## Test plan
- [ ] Verify new patterns appear in `.gitignore`
- [ ] Confirm `.claude/` config directories are still tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)