### PR TITLE
fix(ci): disable Storybook Pages deploy until Pages is configured

### DIFF
--- a/.claude/team/roster.json
+++ b/.claude/team/roster.json
@@ -6,5 +6,10 @@
   "Astrid Lindqvist": "parametrization+Astrid.Lindqvist@gmail.com",
   "Nhan Pham": "parametrization+Nhan.Pham@gmail.com",
   "Kofi Mensah": "parametrization+Kofi.Mensah@gmail.com",
-  "Luciana Ferreyra": "parametrization+Luciana.Ferreyra@gmail.com"
+  "Luciana Ferreyra": "parametrization+Luciana.Ferreyra@gmail.com",
+
+  "Nadia Khoury": "parametrization+Nadia.Khoury@gmail.com",
+  "Wanjiku Mwangi": "parametrization+Wanjiku.Mwangi@gmail.com",
+  "Santiago Ferreira": "parametrization+Santiago.Ferreira@gmail.com",
+  "Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"
 }

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -30,6 +30,13 @@ jobs:
 
   deploy:
     needs: build
+    # Disabled until GitHub Pages is configured for this repo. The deploy
+    # step has been failing on every main push with `404 Failed to create
+    # deployment... Ensure GitHub Pages has been enabled` because Pages
+    # was never turned on. Enabling it is a publishing decision (Storybook
+    # would become public on github.io) and is owned by the project lead,
+    # not a CI hygiene fix. See follow-up issue for tracking.
+    if: false
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

`Deploy Storybook` workflow has been red on every `main` push because GitHub Pages was never enabled — `actions/deploy-pages@v4` 404s. Build job works fine; only the publish step fails.

This PR:
- **Disables** the `deploy` job with `if: false` plus an in-file comment block explaining why and pointing at the follow-up issue.
- **Files** noorinalabs/noorinalabs-design-system#54 to track Pages enablement (publishing decision owned by project lead, not CI sweep).
- Includes the bootstrap commit (10172e1) by Aino that adds Wanjiku, Nadia.K, Santiago, and Aino to the design-system roster — needed so this commit can be authored under the correct identity per the cross-repo charter.

## What this PR is NOT

Not a fix to the underlying Pages-not-configured issue. Enabling Pages is intentionally outside #111 scope — that's a publishing decision, not CI hygiene. Issue #54 captures it for follow-up.

## Disabled CI jobs (load-bearing followup)

- **Job disabled:** `Deploy Storybook` (the `deploy` job in the Storybook publish workflow), gated off via `if: false`.
- **Why disabled:** GitHub Pages is not yet configured for this repo, so `actions/deploy-pages@v4` 404s on every `main` push. Enabling Pages is a publishing/hosting decision owned by the project lead, not a CI-hygiene fix.
- **Load-bearing followup:** noorinalabs/noorinalabs-design-system#54 — *infra: Configure GitHub Pages for Storybook publishing*.
- **Acceptance is load-bearing, not advisory:** per the org charter's "disable-with-followup must be load-bearing" rule, #54's acceptance criteria require (a) configuring Pages, (b) removing `if: false` / re-enabling the `deploy` job, AND (c) green verification of a Storybook publish on `main` — not merely configuring Pages. The followup does not close until the job is re-enabled and verified green.

## TechDebt

Filed: noorinalabs/noorinalabs-design-system#54 — `infra: Configure GitHub Pages for Storybook publishing`.

Refs noorinalabs/noorinalabs-main#111

## Test plan

- [x] Local: `if: false` syntactically valid in GitHub Actions (standard expression).
- [ ] CI: `Deploy Storybook` workflow runs on PR merge to main; `build` job runs and uploads artifact; `deploy` job is skipped (not failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
