### PR TITLE
fix(tokens): drop unused 'Inter' from --font-body fallback chain

### DIFF
--- a/src/tokens/index.ts
+++ b/src/tokens/index.ts
@@ -151,7 +151,7 @@ export const colorsDark = {
 export const fontFamily = {
   arabic: "'Noto Naskh Arabic', serif",
   heading: "'IBM Plex Serif', 'Georgia', serif",
-  body: "'IBM Plex Sans', 'Inter', system-ui, sans-serif",
+  body: "'IBM Plex Sans', system-ui, sans-serif",
   mono: "'IBM Plex Mono', ui-monospace, monospace",
 } as const;
 

--- a/src/tokens/typography.css
+++ b/src/tokens/typography.css
@@ -10,7 +10,7 @@
   /* --- Font families --- */
   --font-arabic: 'Noto Naskh Arabic', serif;
   --font-heading: 'IBM Plex Serif', 'Georgia', serif;
-  --font-body: 'IBM Plex Sans', 'Inter', system-ui, sans-serif;
+  --font-body: 'IBM Plex Sans', system-ui, sans-serif;
   --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
 
   /* --- Modular type scale (1.25 ratio) --- */


### PR DESCRIPTION
Closes #58

## Summary

Removes the unused `'Inter'` fallback from the `--font-body` token chain in both the CSS token (`src/tokens/typography.css`) and TS export (`src/tokens/index.ts`). Inter is never imported or bundled by the design system, so the entry only added Firefox `network.fontVisibility` console noise without any rendering benefit. The fallback now goes `'IBM Plex Sans' → system-ui → sans-serif`.

Two-line change across two files.

## Test Plan

Run from the worktree:

- `npm run lint` — pass (3 pre-existing `react-refresh/only-export-components` warnings on `badge.tsx`, `button.tsx`, `toast.tsx`, unrelated to this change)
- `npm run typecheck` — pass
- `npm run test` — pass (8 files / 67 tests, including `tokens.test.ts`)
- `npm run build` — pass; verified built `dist/styles.css` and `dist/index.js` no longer contain `Inter` in the font-body chain (`--font-body: "IBM Plex Sans", system-ui, sans-serif`).

No Storybook visual tests were re-run; tokens-only change with no rendered surface affected.

## Consumer impact

`isnad-graph` is currently pinned to design-system `0.0.1`, so this fix won't reach consumers until a separate version bump + consumer-side dependency bump is filed and resolved post-publish. Flagging for the orchestrator — not filing the consumer issue from this PR.

## Other refs

`grep -r "[Ii]nter" src/` was run; the only true `'Inter'` references in the codebase were the two changed lines. All other matches are unrelated occurrences of "Interactive" / "Interlocking" in comments.