### PR TITLE
chore(hooks): register validate_pr_ci_status (Hook 14) — sync from parent (#194)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_pr_ci_status.py",
+            "timeout": 15
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

Registers `validate_pr_ci_status.py` (Hook 14) in this repo's `.claude/settings.json` so that `gh pr merge` invocations against design-system PRs are gated on green CI, matching the parent `noorinalabs-main` enforcement.

This is the **third of the symlink-style fan-out PRs** for Hook 14 sync (parent issue: noorinalabs/noorinalabs-main#194). Pattern proven by landing-page#72 (merged 2026-04-28). Identical 1-line settings.json change pointing at the parent's hook file.

## Why this PR is small

The hook .py file already lives at `noorinalabs-main/.claude/hooks/validate_pr_ci_status.py`. This repo's `settings.json` registers shared hooks via parent-canonical absolute paths (the symlink-style pattern). So this PR is a single new entry in the existing `PreToolUse > Bash` matcher list — no file copies needed.

## Architectural context (informational, not in scope)

The two-pattern split (symlink-style vs copy-resident) across child repos is captured in noorinalabs/noorinalabs-main#214 (rationalize to one pattern). This PR ships the gate now to close the immediate red-CI-merge hole.

## Verification

- `python3 -c "import json; json.load(open('.claude/settings.json'))"` — well-formed
- `Bash` matcher entries: 5 → 6 (Hook 14 appended last)
- Diff is byte-identical to landing-page#72 (modulo file path)

## Test plan

- [ ] Reviewer 1 inspects the diff — single matcher entry added at end of Bash hook list
- [ ] Reviewer 2 confirms the parent path `noorinalabs-main/.claude/hooks/validate_pr_ci_status.py` exists and matches landing-page#72's reference
- [ ] After merge: `gh pr merge` against a future PR with a deliberately failing check should block

## Refs

- Parent issue: noorinalabs/noorinalabs-main#194
- Proof-of-pattern PR (merged): noorinalabs-landing-page#72
- Followup #214 (rationalization to single hook-registration pattern, p2-wave-11)
- Charter: `noorinalabs-main/.claude/team/charter/hooks.md` § Hook 14
