### PR TITLE
docs(claude): branching-strategy backslash → slash sync (closes #62)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,4 +105,4 @@ Copy `.env.example` to `.env` if needed. This package has minimal environment co
 - **GitHub Issues** — story/task/bug tracking (created by Manager, assigned to team members)
 - **GitHub Actions** — CI/CD pipelines, automated tests, linting, deployment
 - These three (Projects, Issues, Actions) are the **core orchestration layer** — do not introduce alternative tools for these concerns
-- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}\{IIII}-{issue-name}` (e.g., `F.Okonkwo\0042-setup-storybook`) merged to `main` via PR
+- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}/{IIII}-{issue-name}` (e.g., `F.Okonkwo/0042-setup-storybook`) merged to `main` via PR


### PR DESCRIPTION
## Summary

Sync the parent `noorinalabs-main#232` fix into design-system: `CLAUDE.md` branching-strategy line had a literal backslash that git rejects in refnames. Replaced `\` with `/` on the template and the example.

## Change

Single-line edit at `CLAUDE.md:108`:

```diff
-- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}\{IIII}-{issue-name}` (e.g., `F.Okonkwo\0042-setup-storybook`) merged to `main` via PR
+- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}/{IIII}-{issue-name}` (e.g., `F.Okonkwo/0042-setup-storybook`) merged to `main` via PR
```

## Why this matters

Spawned implementers reading CLAUDE.md verbatim hit `git: 'X.Y\NNNN-...' is not a valid branch name` and have to fall back to repo convention. Two independent confirmations in P3W1 Round 1 (deploy-aisha #179, deploy-lucas #67).

## Wave context

- **Wave:** P3W4 (`deployments/phase-3/wave-4`)
- **Class:** `wave-bootstrap` — single-reviewer exception applies (charter § Single-Reviewer Exception, owner-approved at W4 kickoff, logged in `cross-repo-status.json` `wave_4_decisions.single_reviewer_exception`).
- **Reviewer:** Maeve Callahan (single reviewer)

## Acceptance

- [x] The single affected line in `CLAUDE.md` uses `/` and a `/`-using example.
- [x] Closes #62.

## References

- Parent meta-issue: noorinalabs/noorinalabs-main#232 (parent fix landed on `deployments/phase-3/wave-1`)
- Pattern parallel to W10 Hook 14 fan-out (`noorinalabs-main#194`)

## Test Plan

- [x] `grep -n 'Branching strategy' CLAUDE.md` shows `/` only, no `\`
- [x] git accepts the corrected example branch name (this very PR uses `K.Mensah/0062-...`)

TechDebt: none
