### PR TITLE
fix(design-system #67): settings.json matcher parity with noorinalabs-main

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,58 +6,199 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_commit_identity.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_no_verify.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_git_config.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/auto_set_env_test.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_labels.py",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/dispatcher.py",
             "timeout": 30
           }
         ]
       },
       {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_context.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_ontology_context.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "SendMessage",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_shutdown_without_retro.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_audit.py",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_pr_ci_status.py",
-            "timeout": 15
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/auto_add_issue_to_board.py",
+            "timeout": 20
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/annunaki_monitor.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/ontology_tracker.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/suggest_generic_prompt.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/ontology_tracker.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/suggest_generic_prompt.py",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_handoff.py",
+            "timeout": 30
           }
         ]
       }


### PR DESCRIPTION
Closes #67.

## Summary

Mirror noorinalabs-main `.claude/settings.json` matcher coverage to design-system. Resulting file is **byte-identical** to parent (`diff` returns clean against `/home/parameterization/code/noorinalabs-main/.claude/settings.json`). All commands use parent-canonical absolute paths — no copy-resident hooks introduced.

This closes the matcher-coverage dimension of the symlink-style child contract (`charter/hooks.md § Hook Sync Across Child Repos`). PR #66 closed the copy-resident dimension; #67 was the layer-distinct gap (per `feedback_multi_layer_gap_filing.md`).

## Side-by-side parity diff (child before vs child after)

| Matcher | Before (post-#66) | After (this PR) | Source of new entry |
|---|---|---|---|
| `PreToolUse Bash` | 6 separate matchers (validate_commit_identity, block_no_verify, block_git_config, auto_set_env_test, validate_labels, validate_pr_ci_status) | **1 matcher → `dispatcher.py`** | parent canonical; dispatcher subsumes the 6 prior hooks + 11 more (block_gh_pr_review, block_stale_tmp_message_file, no_worktree_self_delete, validate_edit_completion, validate_lockfile_paths, validate_review_comment_format, validate_pr_review, validate_branch_freshness, validate_workflow_paths_coverage, validate_vps_host, warn_ghcr_image) |
| `PreToolUse Agent` | (none) | validate_wave_context, enforce_ontology_context | parent |
| `PreToolUse SendMessage` | (none) | block_shutdown_without_retro, validate_edit_completion | parent |
| `PreToolUse Skill` | (none) | validate_wave_audit | parent |
| `PreToolUse Edit` | (none) | **enforce_librarian_consulted (Hook 15)**, validate_edit_completion | parent |
| `PreToolUse Write` | (none) | **enforce_librarian_consulted (Hook 15)**, validate_edit_completion | parent |
| `PreToolUse NotebookEdit` | (none) | enforce_librarian_consulted, validate_edit_completion | parent |
| `PostToolUse Bash` | (none) | auto_add_issue_to_board, annunaki_monitor | parent |
| `PostToolUse Edit/Write` | (none) | ontology_tracker, suggest_generic_prompt, validate_edit_completion | parent |
| `PostToolUse NotebookEdit` | (none) | validate_edit_completion | parent |
| `SessionStart` (startup, resume) | (none) | session_start.py | parent |
| `Stop` | (none) | session_handoff.py | parent |

Net: `+152 / -11` lines.

Verification:
```
$ diff /home/parameterization/code/noorinalabs-main/.claude/settings.json .claude/settings.json
$ # (clean — byte-identical)
```

## Smoke test

Hook 15 enforcement was verified at the python-process level (settings.json reload requires session restart, so direct hook invocation is the deterministic test):

**Block path** — Edit on a real repo file with no librarian consultation:
```
$ echo '{"tool_name":"Edit","tool_input":{"file_path":"/home/parameterization/code/noorinalabs-main/noorinalabs-design-system/README.md",...},"cwd":"/home/parameterization/code/noorinalabs-main/noorinalabs-design-system","transcript_path":"/tmp/nonexistent.jsonl"}' \
  | python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py
{"decision": "block", "reason": "BLOCKED: /ontology-librarian must be consulted before code edits in this session..."}
exit=2
```

**Allow path** — same input but with the cwd-keyed sentinel marker fresh from a librarian invocation:
```
$ # after running /ontology-librarian (which writes .claude/.librarian-consulted/<hash>.marker)
$ echo '{"tool_name":"Edit",...,"cwd":"/home/parameterization/code/noorinalabs-main",...}' \
  | python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py
exit=0
```

This confirms Hook 15 will block Edit/Write in worktrees of this repo once a fresh session loads the new settings.json.

## Test Plan

- [x] `diff` against parent settings.json is clean (byte-identical)
- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` — valid JSON
- [x] Hook 15 process-level smoke test: block on no-librarian, allow on fresh sentinel
- [x] All commands resolve to existing files in `/home/parameterization/code/noorinalabs-main/.claude/hooks/`
- [x] `pre-commit run --all-files` — all 5 hooks pass (gitleaks, eslint, typecheck, test, build-and-validate) after `npm ci`
- [ ] **Reviewer runtime check (post-merge / fresh session)**: open a session in this repo, attempt an Edit on `README.md` without first running `/ontology-librarian` → Hook 15 blocks with "BLOCKED: /ontology-librarian must be consulted before code edits in this session." This is a settings-reload gate that cannot be exercised in the same session that authored the change; flagging per `feedback_runtime_gate_scoping.md`.

## Tracking

- Issue: #67 (closes on merge)
- Phase 1 charter spec: noorinalabs/noorinalabs-main#214
- Phase 2 umbrella: noorinalabs/noorinalabs-main#263
- Phase 2 sibling PR (orphan-deletion only): #66
- Phase 2 sibling repo (matcher coverage): noorinalabs/noorinalabs-isnad-graph#862
