### PR TITLE
ci: upgrade Node 20 GitHub Actions to current majors (#74)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -44,10 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: ci
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -17,14 +17,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build:storybook
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: storybook-static
 
@@ -43,4 +43,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Reviewers: Keanu Tama (R1, CI/workflow architecture), Maeve Callahan (R2, manager)

## Summary

Upgrade pinned action majors across all three design-system workflows to remove the Node 20 deprecation warnings GitHub surfaces on every run. Reference target: `noorinalabs-isnad-graph` already runs the same set of majors with no Node 20 deprecation warnings.

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | `actions/checkout@v4 -> @v6` (x2), `actions/setup-node@v4 -> @v6` (x2) |
| `.github/workflows/publish.yml` | `actions/checkout@v4 -> @v6`, `actions/setup-node@v4 -> @v6` |
| `.github/workflows/storybook.yml` | `actions/checkout@v4 -> @v6`, `actions/setup-node@v4 -> @v6`, `actions/upload-pages-artifact@v3 -> @v5`, `actions/deploy-pages@v4 -> @v5` |

10 line changes total across 3 files.

## Verification commands

Verified scope at HEAD (`b71776c`) before editing — file state on origin matched Maeve's pre-grep:
```
gh api "repos/noorinalabs/noorinalabs-design-system/contents/.github/workflows/ci.yml?ref=b71776c9a7250b731ab09fb5ed8fbe1ecb0871a7" --jq '.content' | base64 -d
gh api "repos/noorinalabs/noorinalabs-design-system/contents/.github/workflows/publish.yml?ref=b71776c9a7250b731ab09fb5ed8fbe1ecb0871a7" --jq '.content' | base64 -d
gh api "repos/noorinalabs/noorinalabs-design-system/contents/.github/workflows/storybook.yml?ref=b71776c9a7250b731ab09fb5ed8fbe1ecb0871a7" --jq '.content' | base64 -d
```

Local validation: `actionlint .github/workflows/*.yml` — exit 0. Per the `feedback_actionlint_needs_shellcheck` retro lesson, ran with `shellcheck 0.10.0` on PATH (otherwise actionlint silently skips its shellcheck integration and "clean" diverges from CI gate).

Post-edit version audit:
```
$ grep -E '(actions/checkout|actions/setup-node|actions/upload-pages-artifact|actions/deploy-pages)' .github/workflows/*.yml
.github/workflows/ci.yml:      - uses: actions/checkout@v6
.github/workflows/ci.yml:        uses: actions/setup-node@v6
.github/workflows/ci.yml:      - uses: actions/checkout@v6
.github/workflows/ci.yml:        uses: actions/setup-node@v6
.github/workflows/publish.yml:      - uses: actions/checkout@v6
.github/workflows/publish.yml:        uses: actions/setup-node@v6
.github/workflows/storybook.yml:      - uses: actions/checkout@v6
.github/workflows/storybook.yml:      - uses: actions/setup-node@v6
.github/workflows/storybook.yml:      - uses: actions/upload-pages-artifact@v5
.github/workflows/storybook.yml:        uses: actions/deploy-pages@v5
```

## Caveats

**`storybook.yml` Pages deploy is `if: false`.** The repo's GitHub Pages is not enabled (publishing decision, not CI hygiene — see inline comment, lines 33-38). Practical implication: this PR's `actions/deploy-pages@v5` bump is correct on paper but does not exercise on push; only `actions/upload-pages-artifact@v5` runs end-to-end. End-to-end Pages verification is gated on Pages being enabled, which is a separate publishing decision. The bump is still load-bearing — it removes the Node 20 warning from the disabled branch and pre-positions the workflow for the day Pages is enabled.

**Breaking-change watch (v3 -> v5 for upload-pages-artifact / deploy-pages).** Aino's in-flight Wanjiku audit comment on parent#309 flags that `upload-artifact@v4` is a hard breaking change (per-job artifacts; same name fails). For `upload-pages-artifact` specifically, the v3 -> v4 -> v5 hops are signature-compatible for our usage (single `path:` input, default `artifact_name`); for `deploy-pages` the v4 -> v5 jump is also signature-compatible (no inputs in our call site). Verified by reading the upstream action.yml metadata. No call-site changes needed.

## Cross-wave context

This is the FIRST design-system Node 20 upgrade implementer for P3W8. When this lands it becomes the implicit reference for the other 4 child-repo Node 20 PRs (#280 deploy, #88 landing-page, #46 data-acq, #101 user-service). The verification pattern in this PR body is intentionally explicit so peers can copy it.

## Test plan

- [x] `actionlint .github/workflows/*.yml` exits 0 locally with `shellcheck` on PATH
- [x] Verified file state at origin HEAD before editing (gh api `?ref=<head_sha>`)
- [x] Post-edit version audit shows 0 instances of `@v4` for the four upgraded actions
- [ ] CI green on this PR (`ci.yml` + `validate-package` + `storybook.yml build` job) — REQUIRED before merge per `validate_pr_ci_status` hook
- [ ] No `Node 20 actions are deprecated` warnings in any of the green-run logs (reviewer should spot-check the run summary)
- [ ] `storybook.yml` end-to-end Pages deploy: NOT verifiable until Pages is enabled (out of scope)

Closes noorinalabs/noorinalabs-design-system#74
Refs noorinalabs/noorinalabs-main#309
