### PR TITLE
feat(DS#57): publish @noorinalabs/design-system to GitHub Packages on push-to-main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish to GitHub Packages
 
 on:
+  push:
+    branches: [main]
+    tags: ['v*']
   release:
     types: [published]
 
@@ -31,7 +34,23 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Check if version already published
+        id: version_check
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
+          if npm view "@noorinalabs/design-system@$PKG_VERSION" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "Version $PKG_VERSION already published — skipping publish step."
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "Version $PKG_VERSION not yet on registry — will publish."
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish
+        if: steps.version_check.outputs.already_published == 'false'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to `@noorinalabs/design-system`
+
+## Versioning convention
+
+This package follows [Semantic Versioning](https://semver.org/):
+
+- **PATCH** (`0.0.X`): bug fixes, internal refactors, dependency bumps that do not change the public API.
+- **MINOR** (`0.X.0`): new components, tokens, icons, or props added in a backward-compatible way.
+- **MAJOR** (`X.0.0`): breaking changes — renamed/removed components, changed prop signatures, or token contract changes.
+
+While the package is at `0.x.x`, MINOR bumps may include narrow breaking changes per SemVer 0.x conventions; document any such break in the PR description and the changelog entry.
+
+### When to bump
+
+Every PR that changes runtime behavior, exported API, or published assets MUST bump the version in `package.json` as part of the PR. Reviewers should reject PRs that change behavior without a version bump.
+
+PRs that touch only the following do NOT require a version bump:
+
+- Tests (`*.test.{ts,tsx}`, `*.spec.{ts,tsx}`)
+- Storybook stories (`*.stories.{ts,tsx,mdx}`)
+- Documentation (`README.md`, `docs/**`, this file)
+- CI/workflow configuration (`.github/**`)
+- Internal tooling (`scripts/**`, `.eslintrc`, `prettier.config.*`)
+
+### Publish trigger
+
+`@noorinalabs/design-system` publishes to the GitHub Packages npm registry via `.github/workflows/publish.yml`. The workflow fires on:
+
+1. **Push to `main`** — auto-publishes whatever version is in `package.json`. If the version already exists on the registry, the publish step is skipped (no failure). This means a merge to `main` without a version bump is a no-op publish, by design.
+2. **Tag push matching `v*`** (e.g., `git tag v0.0.4 && git push --tags`) — same publish path, marked semantically as a release.
+3. **Release published** — kept for backward compatibility with the original tag-and-release flow.
+
+For most PRs the push-to-main trigger is sufficient. Use tagged releases for milestones that consumers should pin against.
+
+## Consumer migration
+
+Consumers install this package from GitHub Packages. They need:
+
+1. `.npmrc` at the repo root containing:
+   ```
+   @noorinalabs:registry=https://npm.pkg.github.com
+   ```
+2. A `NODE_AUTH_TOKEN` environment variable with at least `read:packages` scope during `npm ci`. In CI this can be `${{ secrets.GITHUB_TOKEN }}` if the workflow has `packages: read` permission.
+3. In Dockerfiles, pass the token via `--build-arg` from the CI workflow and set it as `NODE_AUTH_TOKEN` for the install step.
+
+For local development, contributors need a personal access token with `read:packages` scope in `~/.npmrc`:
+
+```
+//npm.pkg.github.com/:_authToken=ghp_xxx
+```
+
+## Pull request workflow
+
+Follow the noorinalabs charter conventions:
+
+- Feature branches named `{FirstInitial}.{LastName}/{IIII}-{slug}`
+- Two reviewers per PR (Approved verdict required)
+- No `--no-verify` on commits
+- Commit identity via per-commit `-c` flags (`git -c user.name="..." -c user.email="parametrization+First.Last@gmail.com" commit -F /tmp/<file>.md`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noorinalabs/design-system",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noorinalabs/design-system",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@noorinalabs/design-system",
-  "version": "0.0.2",
+  "version": "0.0.3",
+  "description": "Shared design system for Noorina Labs — OKLCH tokens, Radix-based React components, domain icons, and Qalam brand assets.",
+  "license": "Apache-2.0",
+  "author": "Noorina Labs",
+  "homepage": "https://github.com/noorinalabs/noorinalabs-design-system#readme",
+  "bugs": {
+    "url": "https://github.com/noorinalabs/noorinalabs-design-system/issues"
+  },
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
**Author:** Maeve Callahan (design-system manager)
**Reviewers:** Astrid Lindqvist (r1) + Beren Yildiz (r2) — manager-boundary clean (manager-is-implementer; charter agents.md § Reviewer Slate Discipline)
**Issue:** design-system#57 | **Wave:** p3-wave-10 | **Base:** deployments/phase-3/wave-10

---

## Summary

Resolves design-system#57 — publishes `@noorinalabs/design-system` to GitHub Packages npm registry via push-to-main + tag triggers. This is the **gating precursor** for three downstream issues across two repos:

- isnad-graph#810 — design-system feature consumer
- isnad-graph#840 — design-system feature consumer
- landing-page#73 — design-system feature consumer

Once this merges and the publish workflow successfully ships `0.0.3` to GH Packages, those three issues unblock.

## What this PR ships

| File | Change |
|------|--------|
| `.github/workflows/publish.yml` | Add `push: branches:[main], tags:['v*']` triggers; insert version-already-published guard so merge-to-main without a version bump is a no-op rather than a workflow failure |
| `package.json` | Bump `version` to 0.0.3; add `description`, `license: Apache-2.0`, `author`, `homepage`, `bugs.url` (npm publish was warning on the missing fields) |
| `package-lock.json` | Sync version to 0.0.3 |
| `CONTRIBUTING.md` (new) | Codify versioning discipline (patch/minor/major rules, when bumps are required), document the three publish triggers, and consumer-side `.npmrc` + `NODE_AUTH_TOKEN` setup |

## What this PR does NOT do

Per the DS#57 issue body, consumer migrations were filed as separate downstream issues to keep this PR scoped:

- isnad-graph: `.npmrc`, drop `file:/` reference, Dockerfile `NODE_AUTH_TOKEN` — covered by isnad-graph#840
- landing-page: investigate current resolution path, update `.npmrc`/version pin — covered by landing-page#73
- isnad-graph#810 uses a downstream design-system feature unblocked by this publish

Those issues are blocked on this PR merging + the publish workflow successfully landing 0.0.3 in GH Packages.

## Versioning trigger model

Per CONTRIBUTING.md (new):

1. **Push to `main`** — auto-publishes whatever `package.json` version is current. If that version already exists on the registry, the publish step is skipped (no failure). A merge to `main` without a version bump is a deliberate no-op.
2. **Tag push `v*`** — same publish path, marked semantically as a release.
3. **Release published** — kept for backward compatibility with the original tag-and-release flow.

This addresses side-effect #5 from the issue body ("Versioning collisions ... mixed mode is operationally annoying"): the version-check step makes mixed mode safe.

## Test Plan

### Pre-merge (verified locally on this branch)

- [x] `npm ci` — installs cleanly (578 packages, 0 errors)
- [x] `npm run check` — lint (0 errors, 3 pre-existing warnings), typecheck clean, 67 tests pass across 8 files
- [x] `npm run build` — dist/ generated (index.js 125kB, index.cjs 62kB, styles.css 23kB)
- [x] `npm pack --dry-run` — 80 files, 149.7kB tarball, version 0.0.3, dist/styles.css + dist/index.js + dist/index.cjs all present
- [x] `node scripts/validate-package-exports.mjs` — all critical exports OK
- [x] `actionlint .github/workflows/publish.yml` — clean (with shellcheck on PATH per recent CI hygiene)

### Post-merge (runtime acceptance — NOT a PR gate per charter "PR-Time Acceptance vs Runtime Acceptance")

- [ ] Merge to wave-10 → eventual merge to main triggers the publish workflow
- [ ] Workflow run succeeds: `npm publish` lands `@noorinalabs/design-system@0.0.3` in GH Packages
- [ ] `npm view @noorinalabs/design-system@0.0.3 version --registry=https://npm.pkg.github.com` returns `0.0.3` (with appropriate auth)
- [ ] `gh api /orgs/noorinalabs/packages/npm/design-system/versions` (with `read:packages` scope) shows `0.0.3` alongside `0.0.1`
- [ ] Idempotency check: push another commit to main without a version bump; the workflow should run, hit the version-check step, and skip publish

### Downstream unblocking (tracked separately)

After 0.0.3 is published, these get fresh PRs:

- [ ] isnad-graph#840 consumer migration PR
- [ ] isnad-graph#810 design-system feature consumer PR
- [ ] landing-page#73 consumer migration PR

## Reviewers

- @astrid-lindqvist — component-engineering reviewer (token/component publish-format implications)
- @beren-yildiz — UX/visual lead reviewer (consumer-facing brand asset integrity through publish path)

Manager (Maeve Callahan) is the **implementer** here, not a reviewer — manager-boundary discipline preserved.

## Charter compliance

- Hub-and-spoke: spawned by team-lead per charter agents.md § Single-Leader Constraint
- Worktree isolation: implemented in `noorinalabs-design-system/` worktree
- Branch naming: `M.Callahan/0057-publish-design-system-gh-packages` (charter pattern)
- Commit identity: `Maeve Callahan <parametrization+Maeve.Callahan@gmail.com>` via per-commit `-c` flag + `-F /tmp/57-commit.md`
- No `--no-verify`
- Wave-10 base: `deployments/phase-3/wave-10`

Refs: design-system#57
