### PR TITLE
refactor(DS#53): replace inline SVGs in Toast/DropdownMenu with icon imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noorinalabs/design-system",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noorinalabs/design-system",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noorinalabs/design-system",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Shared design system for Noorina Labs — OKLCH tokens, Radix-based React components, domain icons, and Qalam brand assets.",
   "license": "Apache-2.0",
   "author": "Noorina Labs",

--- a/src/__tests__/icons.test.tsx
+++ b/src/__tests__/icons.test.tsx
@@ -10,6 +10,10 @@ import { CompareIcon } from '../icons/compare-icon'
 import { GraphExplorerIcon } from '../icons/graph-explorer-icon'
 import { TimelineIcon } from '../icons/timeline-icon'
 import { SignOutIcon } from '../icons/sign-out-icon'
+import { CloseIcon } from '../icons/close-icon'
+import { CheckIcon } from '../icons/check-icon'
+import { RadioDotIcon } from '../icons/radio-dot-icon'
+import { ChevronRightIcon } from '../icons/chevron-right-icon'
 import { GeometricBorder } from '../icons/geometric-border'
 import { OctagonalFrame } from '../icons/octagonal-frame'
 import { PageHeaderAccent } from '../icons/page-header-accent'
@@ -105,6 +109,44 @@ describe('SignOutIcon', () => {
   it('renders without crashing', () => {
     const { container } = render(<SignOutIcon />)
     expect(container.querySelector('svg')).toBeDefined()
+  })
+})
+
+describe('CloseIcon', () => {
+  it('renders an SVG with stroke-based paths', () => {
+    const { container } = render(<CloseIcon />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeDefined()
+    expect(svg?.getAttribute('stroke')).toBe('currentColor')
+    expect(svg?.getAttribute('aria-hidden')).toBe('true')
+  })
+})
+
+describe('CheckIcon', () => {
+  it('renders an SVG with stroke-based path', () => {
+    const { container } = render(<CheckIcon />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeDefined()
+    expect(svg?.getAttribute('stroke')).toBe('currentColor')
+  })
+})
+
+describe('RadioDotIcon', () => {
+  it('renders a filled circle', () => {
+    const { container } = render(<RadioDotIcon />)
+    const circle = container.querySelector('circle')
+    expect(circle).toBeDefined()
+    expect(circle?.getAttribute('fill')).toBe('currentColor')
+    expect(circle?.getAttribute('stroke')).toBe('none')
+  })
+})
+
+describe('ChevronRightIcon', () => {
+  it('renders an SVG with stroke-based path', () => {
+    const { container } = render(<ChevronRightIcon />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeDefined()
+    expect(svg?.getAttribute('stroke')).toBe('currentColor')
   })
 })
 

--- a/src/components/dropdown-menu.tsx
+++ b/src/components/dropdown-menu.tsx
@@ -1,5 +1,8 @@
 import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { CheckIcon } from "../icons/check-icon"
+import { ChevronRightIcon } from "../icons/chevron-right-icon"
+import { RadioDotIcon } from "../icons/radio-dot-icon"
 import { cn } from "../utils/cn"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
@@ -67,20 +70,7 @@ const DropdownMenuCheckboxItem = forwardRef<
   >
     <span className="absolute start-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M20 6 9 17l-5-5" />
-        </svg>
+        <CheckIcon size={16} />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -105,15 +95,7 @@ const DropdownMenuRadioItem = forwardRef<
   >
     <span className="absolute start-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="8"
-          height="8"
-          viewBox="0 0 8 8"
-          aria-hidden="true"
-        >
-          <circle cx="4" cy="4" r="4" fill="currentColor" />
-        </svg>
+        <RadioDotIcon size={8} />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -165,21 +147,7 @@ const DropdownMenuSubTrigger = forwardRef<
     {...props}
   >
     {children}
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="ms-auto"
-      aria-hidden="true"
-    >
-      <path d="m9 18 6-6-6-6" />
-    </svg>
+    <ChevronRightIcon size={16} className="ms-auto" />
   </DropdownMenuPrimitive.SubTrigger>
 ))
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName

--- a/src/components/toast.tsx
+++ b/src/components/toast.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from "react"
 import * as ToastPrimitive from "@radix-ui/react-toast"
 import { cva, type VariantProps } from "class-variance-authority"
+import { CloseIcon } from "../icons/close-icon"
 import { cn } from "../utils/cn"
 
 const ToastProvider = ToastPrimitive.Provider
@@ -96,21 +97,7 @@ const ToastClose = forwardRef<
     toast-close=""
     {...props}
   >
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M18 6 6 18" />
-      <path d="m6 6 12 12" />
-    </svg>
+    <CloseIcon size={16} />
   </ToastPrimitive.Close>
 ))
 ToastClose.displayName = ToastPrimitive.Close.displayName

--- a/src/icons/check-icon.tsx
+++ b/src/icons/check-icon.tsx
@@ -1,0 +1,11 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Check — confirmation glyph for checkbox indicators, success states, and selected items */
+export function CheckIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M20 6 9 17l-5-5" />
+    </IconBase>
+  )
+}

--- a/src/icons/chevron-right-icon.tsx
+++ b/src/icons/chevron-right-icon.tsx
@@ -1,0 +1,11 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** ChevronRight — directional glyph for sub-menu triggers and expandable rows */
+export function ChevronRightIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="m9 18 6-6-6-6" />
+    </IconBase>
+  )
+}

--- a/src/icons/close-icon.tsx
+++ b/src/icons/close-icon.tsx
@@ -1,0 +1,12 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Close — X / dismiss glyph for modals, toasts, and dismissible chips */
+export function CloseIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </IconBase>
+  )
+}

--- a/src/icons/icons.stories.tsx
+++ b/src/icons/icons.stories.tsx
@@ -9,6 +9,10 @@ import {
   GraphExplorerIcon,
   AdminIcon,
   SignOutIcon,
+  CloseIcon,
+  CheckIcon,
+  RadioDotIcon,
+  ChevronRightIcon,
   NoResultsIllustration,
   EmptyGraphIllustration,
   NoDataIllustration,
@@ -29,6 +33,10 @@ const icons = [
   { name: 'GraphExplorerIcon', Component: GraphExplorerIcon },
   { name: 'AdminIcon', Component: AdminIcon },
   { name: 'SignOutIcon', Component: SignOutIcon },
+  { name: 'CloseIcon', Component: CloseIcon },
+  { name: 'CheckIcon', Component: CheckIcon },
+  { name: 'RadioDotIcon', Component: RadioDotIcon },
+  { name: 'ChevronRightIcon', Component: ChevronRightIcon },
 ]
 
 function IconGallery(props: IconProps) {

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -16,6 +16,12 @@ export { GraphExplorerIcon } from './graph-explorer-icon'
 export { AdminIcon } from './admin-icon'
 export { SignOutIcon } from './sign-out-icon'
 
+// Utility / interaction icons (used internally by components, also exported for consumers)
+export { CloseIcon } from './close-icon'
+export { CheckIcon } from './check-icon'
+export { RadioDotIcon } from './radio-dot-icon'
+export { ChevronRightIcon } from './chevron-right-icon'
+
 // Empty state illustrations
 export { NoResultsIllustration } from './no-results-illustration'
 export { EmptyGraphIllustration } from './empty-graph-illustration'

--- a/src/icons/radio-dot-icon.tsx
+++ b/src/icons/radio-dot-icon.tsx
@@ -5,7 +5,7 @@ import { IconBase } from './icon-base'
 export function RadioDotIcon(props: IconProps) {
   return (
     <IconBase {...props}>
-      <circle cx="12" cy="12" r="4" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12" r="12" fill="currentColor" stroke="none" />
     </IconBase>
   )
 }

--- a/src/icons/radio-dot-icon.tsx
+++ b/src/icons/radio-dot-icon.tsx
@@ -1,0 +1,11 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** RadioDot — filled dot indicator for radio item selection */
+export function RadioDotIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <circle cx="12" cy="12" r="4" fill="currentColor" stroke="none" />
+    </IconBase>
+  )
+}


### PR DESCRIPTION
**Author:** Astrid Lindqvist (component-engineering implementer)
**Reviewers:** Keanu Tama (r1) + Maricel Reyes (r2) — PD-substituted slate, manager-boundary clean (Maeve absent)
**Issue:** design-system#53 | **Wave:** p3-wave-10 | **Base:** deployments/phase-3/wave-10

---

## Summary

Resolves design-system#53 — replaces the 4 inline `<svg>` elements in Toast and DropdownMenu with icon-component imports from `src/icons/`, bringing them in line with the rest of the codebase and the Qalam brand iconography contract (24x24, 1.5px stroke, currentColor).

## Scope decision (caveat resolution)

The DS#53 issue body asks to "replace inline SVGs with imports from `src/icons/`" — but at issue-filing time the matching icons did NOT exist in `src/icons/`. Per the spawn-brief CAVEAT (Maeve's manager guidance), I went with **Option (a)**: create the 4 icons + swap them in, in this PR. Gating on a tiny precursor PR would be process churn for 4 trivial stroke-based glyphs.

## What this PR ships

### 4 new icon components (`src/icons/`)

| File | Glyph | Pattern |
|------|-------|---------|
| `close-icon.tsx` | `CloseIcon` (X / dismiss) | 2 stroke paths via `IconBase` |
| `check-icon.tsx` | `CheckIcon` (checkmark) | 1 stroke path via `IconBase` |
| `radio-dot-icon.tsx` | `RadioDotIcon` (filled dot) | `<circle fill="currentColor" stroke="none">` inside `IconBase` (matches NarratorsIcon/SearchIcon fill-override technique) |
| `chevron-right-icon.tsx` | `ChevronRightIcon` (right-pointing chevron) | 1 stroke path via `IconBase` |

### Barrel export (`src/icons/index.ts`)

Added a new "Utility / interaction icons" section after the functional icons block. Exports `CloseIcon, CheckIcon, RadioDotIcon, ChevronRightIcon`.

### Storybook (`src/icons/icons.stories.tsx`)

Added the 4 new icons to the unified gallery (matches the actual project pattern — the gallery story is shared across all icons rather than per-icon files).

### Component swaps

- `Toast.ToastClose` — inline `<svg>` X-glyph → `<CloseIcon size={16} />`
- `DropdownMenu.CheckboxItem` indicator — inline `<svg>` checkmark → `<CheckIcon size={16} />`
- `DropdownMenu.RadioItem` indicator — inline `<svg><circle>` filled dot → `<RadioDotIcon size={8} />`
- `DropdownMenu.SubTrigger` chevron — inline `<svg>` chevron → `<ChevronRightIcon size={16} className="ms-auto" />`

### Tests (`src/__tests__/icons.test.tsx`)

4 new describe-blocks. CloseIcon asserts stroke=currentColor + aria-hidden="true". CheckIcon and ChevronRightIcon assert stroke=currentColor. RadioDotIcon asserts the filled-circle override (fill=currentColor, stroke=none). Total test count: 67 → 71.

### Version bump

`package.json`: `0.0.3 → 0.0.4` (PATCH). Per CONTRIBUTING.md (merged via DS#57 / PR #77), new icons argue for MINOR ("new components, tokens, icons, or props added in a backward-compatible way"). I chose PATCH because:

1. The new icons are reachable only through the **existing** `.` and `./icons` barrel exports — no new top-level export path is introduced.
2. The component swap into Toast/DropdownMenu is internal refactor, not API change.
3. 0.x.x carveout supports either reading; PATCH is the conservative pick.

**Reviewers may push for 0.1.0 (MINOR)** — I'll happily bump if either reviewer prefers strict-letter-of-CONTRIBUTING. Flagging this explicitly so the call is yours.

## Stroke-width note (the tech-debt cleanup)

The inline SVGs used `strokeWidth="2"`. The new icons inherit `strokeWidth="1.5"` from `IconBase` per the documented Qalam brand standard (`docs/brand/iconography.md`, `ontology/repos/design-system.yaml`). This is precisely the drift DS#53 was filed to fix — the inline glyphs were inconsistent with the brand contract. **Expect a barely-perceptible visual change** to the close X, checkmark, radio dot indicator scaling, and sub-menu chevron — the strokes will be slightly thinner. This is intentional per the brand standard.

## Test Plan

### Pre-merge (verified locally on this branch)

- [x] `npm run check` — lint (0 errors, 3 pre-existing warnings on Badge/Button/Toast — all `react-refresh/only-export-components` unrelated to this PR), typecheck clean, **71 tests pass** across 8 files (up from 67 — 4 new icon tests)
- [x] `npm run build` — dist/ generated (index.js 124kB, index.cjs 61kB, styles.css 23kB — same shape as base)
- [x] `node scripts/validate-package-exports.mjs` — all critical exports OK
- [x] `npm pack --dry-run` — 88 files (up from 84 — adds .d.ts/.js for 4 new icons), 151.1kB tarball, version 0.0.4

### Post-merge (consumer-side)

- [ ] On next publish (DS#57's publish workflow), `@noorinalabs/design-system@0.0.4` lands in GH Packages with new icons available via barrel
- [ ] Consumers using `<Toast>` and `<DropdownMenu>` get the slightly-thinner Qalam-brand-standard 1.5px stroke automatically (no consumer-side changes needed)

## Charter compliance

- Hub-and-spoke: spawned by team-lead per charter `agents.md` § Single-Leader Constraint
- Worktree isolation: implemented in `.claude/worktrees/A.Lindqvist-0053-replace-inline-svgs/`
- Branch naming: `A.Lindqvist/0053-replace-inline-svgs-with-icon-imports` (charter pattern)
- Commit identity: `Astrid Lindqvist <parametrization+Astrid.Lindqvist@gmail.com>` via per-commit `-c` flag + `-F /tmp/53-icons-swap.md`
- No `--no-verify`
- Wave-10 base: `deployments/phase-3/wave-10`
- Rebased onto current `origin/deployments/phase-3/wave-10` (post-PR-#77 merge) — branch is up-to-date

## Reviewers

- @keanu-tama — component-engineering reviewer (R1; PD-substituted, manager-boundary clean)
- @maricel-reyes — component-engineering reviewer (R2; PD-substituted)

Manager (Maeve Callahan) absent for DS#53; PD substituted reviewer slate per charter `agents.md` § Reviewer Slate Discipline.

Refs: design-system#53
