### PR TITLE
feat(DS#57-followup): wave-branch publish trigger + 0.0.4-wave10.0 pre-release + CONTRIBUTING semver

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,9 @@ name: Publish to GitHub Packages
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'deployments/**'
     tags: ['v*']
   release:
     types: [published]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,28 @@ PRs that touch only the following do NOT require a version bump:
 `@noorinalabs/design-system` publishes to the GitHub Packages npm registry via `.github/workflows/publish.yml`. The workflow fires on:
 
 1. **Push to `main`** — auto-publishes whatever version is in `package.json`. If the version already exists on the registry, the publish step is skipped (no failure). This means a merge to `main` without a version bump is a no-op publish, by design.
-2. **Tag push matching `v*`** (e.g., `git tag v0.0.4 && git push --tags`) — same publish path, marked semantically as a release.
-3. **Release published** — kept for backward compatibility with the original tag-and-release flow.
+2. **Push to `deployments/**`** (wave branches) — publishes wave pre-releases for cross-repo consumers. See "Wave-branch pre-releases" below.
+3. **Tag push matching `v*`** (e.g., `git tag v0.0.4 && git push --tags`) — same publish path, marked semantically as a release.
+4. **Release published** — kept for backward compatibility with the original tag-and-release flow.
 
 For most PRs the push-to-main trigger is sufficient. Use tagged releases for milestones that consumers should pin against.
+
+### Wave-branch pre-releases
+
+Cross-repo wave work (Phase 3 wave-10 and forward) sometimes needs consumers in sibling repos to depend on an unreleased design-system change before the wave branch merges to `main`. To support that, wave branches under `deployments/**` are allowed to publish **pre-release** semver versions to GitHub Packages.
+
+**Pre-release version format:** `<X.Y.Z>-wave<N>.<patch>` where:
+
+- `<X.Y.Z>` is the SemVer base — the version that will become canonical once this wave merges to `main`.
+- `<N>` is the wave number (e.g., `10` for `deployments/phase-3/wave-10`).
+- `<patch>` increments per re-cut on the same wave branch, starting at `0` (e.g., `0.0.3-wave10.0`, `0.0.3-wave10.1` if a follow-up fix is required mid-wave).
+
+**Rules:**
+
+- The main-branch publish remains the **canonical release**. Pre-releases are time-bounded by their wave's lifespan and exist to unblock cross-repo integration during the wave, not to ship to end users.
+- Consumers depending on a wave pre-release MUST pin the exact version (e.g., `"@noorinalabs/design-system": "0.0.3-wave10.0"`) — SemVer range matchers do not auto-include pre-release versions, which is the desired behavior here.
+- When the wave branch merges to `main`, bump the version in the merge to the canonical `<X.Y.Z>` (drop the `-wave<N>.<patch>` suffix) and let the main-branch publish trigger ship the canonical release. Consumers should then move their pin to the canonical version in a follow-up PR.
+- A wave branch may publish multiple `<patch>` increments during its lifespan; each must bump the suffix patch number to avoid registry collision (the `npm view` guard would otherwise skip the re-publish).
 
 ## Consumer migration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noorinalabs/design-system",
-  "version": "0.0.4",
+  "version": "0.0.4-wave10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noorinalabs/design-system",
-      "version": "0.0.4",
+      "version": "0.0.4-wave10.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noorinalabs/design-system",
-  "version": "0.0.4",
+  "version": "0.0.4-wave10.0",
   "description": "Shared design system for Noorina Labs — OKLCH tokens, Radix-based React components, domain icons, and Qalam brand assets.",
   "license": "Apache-2.0",
   "author": "Noorina Labs",


### PR DESCRIPTION
**Author:** Maeve Callahan (design-system manager)
**Reviewers:** Astrid Lindqvist (r1) + Luciana Ferreyra (r2) — manager-boundary clean (manager-is-implementer)
**Refs:** design-system#57 (closed, merged via #77); follow-up scoped per owner authorization 2026-05-14 wave-10 mid-wave
**Wave:** p3-wave-10 | **Base:** `deployments/phase-3/wave-10` (currently `afdb2da4`) | **Head:** `14ce6833` (branch `M.Callahan/0057-followup-wave-branch-publish-trigger`)

---

## Update history

- **v1 (`7ac482c`):** Initial PR opened against `2c766fa` (wave-10 pre-#79). Bumped `0.0.3 → 0.0.3-wave10.0`.
- **v2 (`14ce6833`):** Rebased onto wave-10 HEAD `afdb2da4` (post-#79). Per Astrid's v1 ChangesRequested verdict, bumped to `0.0.4-wave10.0` — the prior `0.0.3-wave10.0` was a **SemVer regression** against wave-10's `0.0.4` baseline (per SemVer 2.0.0 §11.4: `0.0.4-wave10.0 < 0.0.4`, so publishing the wave artifact would have made it strictly older than what wave-10 already contained, reversing the unblock intent).

## Summary

Wave-flow follow-up to #57 / #77 (merged precursor at `2c766fa`). Adds wave-branch publish triggers and a pre-release semver convention so cross-repo consumers can depend on design-system changes during the wave instead of waiting for the wave-10 → main merge.

## Unblock rationale (per owner authorization)

Three cross-repo consumer PRs are gated on a wave-published `@noorinalabs/design-system` build being available on the GitHub Packages registry:

- isnad-graph#810 — design-system feature consumer
- isnad-graph#840 — frontend pin migration (`file:/` tarball → registry version)
- landing-page#73 — landing-page consumer migration

Per #77, publishes only fire on push-to-main / tag-`v*` / release. The wave-10 → main merge happens at `/wave-wrapup` — which would block these three PRs from being implementable until then. To unblock the cross-repo work without waiting, this PR expands the push trigger to include `deployments/**` branches and ships a pre-release semver tagged `0.0.4-wave10.0`. Consumers can pin to the pre-release during the wave, then move their pins to canonical `0.0.4` once the wave merges to main.

This is a wave-flow-specific extension of #57's main-branch publish convention — not a replacement for it.

## SemVer judgment (PATCH-level)

Per CONTRIBUTING.md `Versioning convention`: PATCH is for "bug fixes, internal refactors, dependency bumps that do not change the public API." Two inputs to the `0.0.4-wave10.0` choice:

- **#79 (SVG→icon refactor in Toast/DropdownMenu)** — internal refactor, no exported-API change. Already bumped wave-10 from `0.0.3 → 0.0.4` as a PATCH.
- **This PR (workflow + CONTRIBUTING + version)** — no exported-API change at all (publishing infrastructure only).

Neither input warrants MINOR. Owner default of `0.0.4-wave10.0` matches CONTRIBUTING-canonical semantics. (If a future wave-branch PR adds new components or props, that PR should bump to `0.1.0-wave10.<N>` per CONTRIBUTING MINOR rules.)

## What this PR ships

| File | Change |
|------|--------|
| `.github/workflows/publish.yml` | Add `deployments/**` to `on.push.branches` alongside `main`. The existing `npm view` version-already-published guard continues to prevent double-publishes for unbumped wave commits. |
| `package.json` | Bump `version` from `0.0.4` (wave-10 baseline post-#79) to `0.0.4-wave10.0` (pre-release semver per the new convention). |
| `package-lock.json` | Sync root + `packages[""]` `version` to `0.0.4-wave10.0`. |
| `CONTRIBUTING.md` | Add wave-branch trigger as item 2 in the 4-trigger list. Add new "Wave-branch pre-releases" section codifying the `<X.Y.Z>-wave<N>.<patch>` format, consumer pin rules, and wave → main canonical-bump step. |

## Versioning convention added

Per the CONTRIBUTING.md amendment:

```
<X.Y.Z>-wave<N>.<patch>
```

- `<X.Y.Z>` — SemVer base; the canonical version once this wave merges to main.
- `<N>` — wave number (e.g., `10` for `deployments/phase-3/wave-10`).
- `<patch>` — increments per re-cut on the same wave branch (starts at `0`).

Consumers MUST pin the exact version (SemVer range matchers don't auto-include pre-releases — desired behavior). When the wave merges, drop the suffix and the main-branch publish trigger ships the canonical `<X.Y.Z>` release.

## What this PR does NOT do

- Does not modify the existing main-branch publish path from #77.
- Does not change anything about the version-already-published guard logic — same `npm view` shape, same skip-on-collision behavior.
- Does not auto-bump pre-release patch numbers; mid-wave re-cuts on the same wave branch require an explicit bump (e.g., `0.0.4-wave10.0` → `0.0.4-wave10.1`).
- Does not require a `Closes #57` since #57 is already CLOSED (closed by #77's merge close-comment).

## Runtime acceptance compounding risk (acknowledged)

#77 shipped the main-branch publish path; it has not yet fired in production (wave-10 has not merged to main). This PR layers wave-branch publish behavior on top of an unverified main-branch path. Owner accepted this risk on 2026-05-14 with the reasoning that the 3 gated consumer PRs need unblock-sooner and main-branch validation will run in parallel (W11 retro will retire the risk).

If the main-branch publish fails after wave-10 merges to main, debugging will need to disentangle whether the failure mode is shared with the wave-branch path or specific to one trigger. We'll handle that in retro if it materializes.

## Test Plan

### Pre-merge (local)

- [x] `actionlint .github/workflows/publish.yml` — clean (shellcheck on PATH per recent CI hygiene)
- [x] `python3 -c "import yaml; ..."` — workflow parses, triggers correctly include `['main', 'deployments/**']`
- [x] `package.json` + `package-lock.json` version sync verified: both at `0.0.4-wave10.0` (root + `packages[""]`)
- [x] `npm install` — lockfile sane after version bump
- [x] `npm run build` — vite build passes (44 modules, dist/index.js 124kB, dist/styles.css 23kB, dist/index.cjs 61kB)
- [x] `git diff --stat origin/deployments/phase-3/wave-10` — 4 files / +26 / -6 (no rebase-fallout)

### Post-merge (runtime — NOT a PR gate per charter `pull-requests.md § PR-Time Acceptance vs Runtime Acceptance`)

- [ ] Merge to wave-10 triggers the publish workflow
- [ ] Workflow run lands `@noorinalabs/design-system@0.0.4-wave10.0` in GitHub Packages
- [ ] `npm view @noorinalabs/design-system@0.0.4-wave10.0 version --registry=https://npm.pkg.github.com` returns `0.0.4-wave10.0`
- [ ] Idempotency: push another commit to wave-10 without bumping the suffix patch; workflow runs, version-check skips publish (no failure)

### Downstream unblocking (tracked separately)

After `0.0.4-wave10.0` lands on the registry, these get fresh implementation PRs:

- [ ] isnad-graph#810 — design-system feature consumer
- [ ] isnad-graph#840 — frontend pin migration to `0.0.4-wave10.0`
- [ ] landing-page#73 — landing-page consumer migration

## Charter compliance

- Hub-and-spoke: spawned by team-lead per charter `agents.md § Single-Leader Constraint`
- Worktree isolation: `noorinalabs-design-system/.claude/worktrees/M.Callahan-0057-followup-wave-publish-trigger/`
- Branch naming: `M.Callahan/0057-followup-wave-branch-publish-trigger` (charter pattern)
- Commit identity: `Maeve Callahan <parametrization+Maeve.Callahan@gmail.com>` via per-commit `-c` flag + `-F /tmp/maeve_0057_v2_commit.md`
- No `--no-verify`. v2 force-push used `--force-with-lease` (correct per rebase semantics).
- Wave-10 base: `deployments/phase-3/wave-10`
- All facts in this body verified at origin head (`gh api .../contents/...?ref=...`) before push

Refs: design-system#57 / design-system#77 (precursor) / isnad-graph#810 / isnad-graph#840 / landing-page#73 (gated)
