### PR TITLE
tech-debt(DS#83): fix charter org-doc links that break in standalone clone + worktree

### DIFF
--- a/.claude/team/charter.md
+++ b/.claude/team/charter.md
@@ -1,5 +1,11 @@
 # Team Charter — noorinalabs-design-system
 
+## Repository Context
+
+`noorinalabs-design-system` is a **child repository of the `noorinalabs-main` organization repo**. It is an independent git repository (own branches, PRs, CI) that is normally cloned beneath `noorinalabs-main/`, but it can also be cloned standalone.
+
+Org-wide rules live once in the `noorinalabs-main` charter. The "Shared Rules" links below point to the canonical copies via GitHub URLs so they resolve from a standalone clone, a nested clone, or a worktree checkout alike. When working inside `noorinalabs-main`, the same docs are on disk at `noorinalabs-main/.claude/team/charter/`.
+
 ## Purpose
 
 All work on the noorinalabs-design-system repository is executed through a simulated team of specialized agents. Every problem-solving session MUST instantiate this team structure. No work begins without the Manager spawning the appropriate team members.
@@ -13,18 +19,18 @@ All work on the noorinalabs-design-system repository is executed through a simul
 
 ## Shared Rules (Org Charter)
 
-The following rules are defined once in the org charter and apply to all repos. Agents MUST load the relevant sub-doc when performing that activity.
+The following rules are defined once in the org charter and apply to all repos. Agents MUST load the relevant sub-doc when performing that activity. Links point to the canonical copies in `noorinalabs-main` (see Repository Context above).
 
 | Topic | Reference |
 |-------|-----------|
-| Issue comments, reply protocol, delegation, assignment, hygiene | [Org § Issues](../../../.claude/team/charter/issues.md) |
-| Branching rules, deployments branches, worktree cleanup | [Org § Branching](../../../.claude/team/charter/branching.md) |
-| Commit identity, co-author trailers | [Org § Commits](../../../.claude/team/charter/commits.md) |
-| PR workflow, CI enforcement, consolidated PRs, cross-PR deps | [Org § Pull Requests](../../../.claude/team/charter/pull-requests.md) |
-| Agent naming, lifecycle, hub-and-spoke, team lifecycle | [Org § Agents](../../../.claude/team/charter/agents.md) |
-| Hooks (validate identity, block --no-verify, block git config, auto env test, validate labels) | [Org § Hooks](../../../.claude/team/charter/hooks.md) |
-| Tech preferences, debate, tie-breaking (LCA) | [Org § Tech Decisions](../../../.claude/team/charter/tech-decisions.md) |
-| Cross-repo communication protocol | [Org § Communication](../../../.claude/team/charter/communication.md) |
+| Issue comments, reply protocol, delegation, assignment, hygiene | [Org § Issues](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/issues.md) |
+| Branching rules, deployments branches, worktree cleanup | [Org § Branching](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/branching.md) |
+| Commit identity, co-author trailers | [Org § Commits](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/commits.md) |
+| PR workflow, CI enforcement, consolidated PRs, cross-PR deps | [Org § Pull Requests](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/pull-requests.md) |
+| Agent naming, lifecycle, hub-and-spoke, team lifecycle | [Org § Agents](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/agents.md) |
+| Hooks (validate identity, block --no-verify, block git config, auto env test, validate labels) | [Org § Hooks](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/hooks.md) |
+| Tech preferences, debate, tie-breaking (LCA) | [Org § Tech Decisions](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/tech-decisions.md) |
+| Cross-repo communication protocol | [Org § Communication](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/communication.md) |
 
 ## Issue Review Process
 
@@ -136,7 +142,7 @@ Each team member maintains a directional trust score (1-5). Default is 3 (neutra
 | Kofi Mensah | `Kofi Mensah` | `parametrization+Kofi.Mensah@gmail.com` |
 | Luciana Ferreyra | `Luciana Ferreyra` | `parametrization+Luciana.Ferreyra@gmail.com` |
 
-See [Org § Commits](../../../.claude/team/charter/commits.md) for the commit format, co-author trailers, and identity rules.
+See [Org § Commits](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/commits.md) for the commit format, co-author trailers, and identity rules.
 
 ## Automated Enforcement (Git Hooks)
 
@@ -152,7 +158,7 @@ See [Org § Commits](../../../.claude/team/charter/commits.md) for the commit fo
 
 GitHub repository rulesets requiring at least 1 approving review on all PRs targeting `deployments/**` branches. Emergency override: repository admins can bypass via the GitHub UI (hotfix scenarios only with Manager approval).
 
-See [Org § Hooks](../../../.claude/team/charter/hooks.md) for Claude Code hook details (validate identity, block --no-verify, block git config, auto env test, validate labels).
+See [Org § Hooks](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/hooks.md) for Claude Code hook details (validate identity, block --no-verify, block git config, auto env test, validate labels).
 
 ## Steady-State Goal
 


### PR DESCRIPTION
## Summary

Closes #83. Investigated against wave-11 HEAD (`73f8236`) — this is a **mechanical fix, no design decision needed**. Mirrors the pattern of [noorinalabs-user-service#15 / PR #120](https://github.com/noorinalabs/noorinalabs-user-service/pull/120) (merged 2026-05-15).

### What was broken

`.claude/team/charter.md` linked to the 8 org-level charter sub-docs via `../../../.claude/team/charter/<doc>.md` relative paths.

**Pre-fix enumeration:** Found **10 occurrences across 1 file** (`.claude/team/charter.md`):
- 8 in the Shared Rules table (lines 20-27)
- 1 inline reference to `commits.md` (line 139)
- 1 inline reference to `hooks.md` (line 155)

Those paths resolve **only** when the repo sits exactly at `noorinalabs-main/noorinalabs-design-system/`. They are broken in two situations:

1. **Standalone clone** — the org docs don't exist on disk at all; nothing to resolve to.
2. **Worktree checkout** — `.claude/worktrees/<name>/` sits deeper than three levels, so `../../../` already missed the org root even *inside* `noorinalabs-main`.

### The fix

Replaced all 10 relative-path references with **GitHub blob URLs** to the canonical copies:
`https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/<doc>.md`

GitHub URLs resolve identically from a standalone clone, a nested clone, and a worktree checkout, and render as working links on GitHub. Added a short **Repository Context** section stating that `noorinalabs-design-system` is a child repo of `noorinalabs-main`, and noting the on-disk path (`noorinalabs-main/.claude/team/charter/`) for anyone working inside the org checkout.

### Diff scope

Single file, +17 / -11 — same shape as US PR#120 (which was +17 / -11 on 11 refs; we have +17 / -11 on 10 refs because DS's hook section is structured slightly differently and didn't need a third inline rewrite).

### Approaches considered and rejected (per issue #83)

- **Vendor/copy the org docs into each child repo** — rejected. The org charter is explicitly built on single-source-of-truth ("defined once in the org charter and apply to all repos"); copying would create drift and contradict that design.
- **Symlinks** — rejected. Don't survive a standalone clone either, and fragile cross-platform.

### Out of scope

- Worktree clones under `.claude/worktrees/*/` contain mirror copies of the broken paths — these will pick up the fix on rebase, matching US PR#120's scope.
- 4 `CLAUDE.md` files in worktrees reference `../../.claude/team/charter.md` (2-level, in-repo `canonical: ...` pointer to this same charter) — these are NOT broken org-doc refs and US PR#120 did not touch them.

## Live-trace evidence

**Pre-fix** (on this branch, before this commit):
```
$ grep -c "\.\./\.\./\.\./\.claude/team/charter" .claude/team/charter.md
10
```

**Post-fix** (this commit):
```
$ grep -n "\.\./\.\./\.\./\.claude/team/charter" .claude/team/charter.md
$ echo "exit=$?"
exit=1
$ find . -name "*.md" -path "*/.claude/*" -exec grep -l "\.\./\.\./\.\./\.claude" {} \;
(empty)
```

## Tech Debt

None introduced. This PR removes tech debt; no new tech debt.

## Test plan

- [x] `grep "\.\./" .claude/team/charter.md | grep -c "charter/"` → 0 remaining relative-path references
- [x] All 8 org charter sub-doc targets exist on `noorinalabs-main` `main` under `.claude/team/charter/` (issues, branching, commits, pull-requests, agents, hooks, tech-decisions, communication)
- [x] Docs-only change — no code, no tests, no CI gates affected
- [x] Render-check: blob URLs are well-formed and point at existing files

## Reviewers

- Primary: @Astrid Lindqvist (Component Engineer, design-system)
- Secondary: @Aino Virtanen (Standards Lead, parent org — charter authority; cross-team)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
