### PR TITLE
tokens: add --container-* @theme namespace (Tailwind 4 stock scale) — closes #82

### DIFF
--- a/src/__tests__/tokens.test.ts
+++ b/src/__tests__/tokens.test.ts
@@ -7,6 +7,7 @@ import {
   fontWeight,
   lineHeight,
   spacing,
+  container,
   radius,
   zIndex,
   shadow,
@@ -67,6 +68,12 @@ describe('design tokens', () => {
     expect(spacing[0]).toBe('0')
   })
 
+  it('exports container width tokens (Tailwind 4 stock scale)', () => {
+    expect(container.md).toBe('28rem')
+    expect(container['3xs']).toBe('16rem')
+    expect(container['7xl']).toBe('80rem')
+  })
+
   it('exports radius tokens', () => {
     expect(radius.full).toBe('9999px')
     expect(radius.md).toBe('0.375rem')
@@ -98,6 +105,7 @@ describe('design tokens', () => {
     expect(tokens.fontFamily).toBe(fontFamily)
     expect(tokens.fontSize).toBe(fontSize)
     expect(tokens.spacing).toBe(spacing)
+    expect(tokens.container).toBe(container)
     expect(tokens.radius).toBe(radius)
     expect(tokens.shadow).toBe(shadow)
     expect(tokens.duration).toBe(duration)

--- a/src/tokens/container.css
+++ b/src/tokens/container.css
@@ -1,0 +1,26 @@
+/*
+ * Container Tokens — Qalam Design System
+ * ========================================
+ * Tailwind 4's `--container-*` theme namespace drives `max-w-*` / `min-w-*`
+ * utilities. Mirrors Tailwind's stock scale so consumers importing
+ * @noorinalabs/design-system/styles.css resolve `max-w-md` etc. correctly.
+ *
+ * Without this namespace, `max-w-md` falls through to `--spacing-md` (1rem),
+ * producing 16px-wide containers — see issue #82 (latent #889-class bugs).
+ */
+
+@theme {
+  --container-3xs: 16rem;
+  --container-2xs: 18rem;
+  --container-xs: 20rem;
+  --container-sm: 24rem;
+  --container-md: 28rem;
+  --container-lg: 32rem;
+  --container-xl: 36rem;
+  --container-2xl: 42rem;
+  --container-3xl: 48rem;
+  --container-4xl: 56rem;
+  --container-5xl: 64rem;
+  --container-6xl: 72rem;
+  --container-7xl: 80rem;
+}

--- a/src/tokens/index.css
+++ b/src/tokens/index.css
@@ -8,4 +8,5 @@
 @import './colors.css';
 @import './typography.css';
 @import './spacing.css';
+@import './container.css';
 @import './shadows.css';

--- a/src/tokens/index.ts
+++ b/src/tokens/index.ts
@@ -225,6 +225,26 @@ export const spacingSemantic = {
 } as const;
 
 // ---------------------------------------------------------------------------
+// Container widths (Tailwind 4 stock scale — drives max-w-* / min-w-*)
+// ---------------------------------------------------------------------------
+
+export const container = {
+  '3xs': '16rem',
+  '2xs': '18rem',
+  xs: '20rem',
+  sm: '24rem',
+  md: '28rem',
+  lg: '32rem',
+  xl: '36rem',
+  '2xl': '42rem',
+  '3xl': '48rem',
+  '4xl': '56rem',
+  '5xl': '64rem',
+  '6xl': '72rem',
+  '7xl': '80rem',
+} as const;
+
+// ---------------------------------------------------------------------------
 // Radii
 // ---------------------------------------------------------------------------
 
@@ -315,6 +335,7 @@ export const tokens = {
   arabicTypography,
   spacing,
   spacingSemantic,
+  container,
   radius,
   zIndex,
   shadow,


### PR DESCRIPTION
## Summary

Adds Tailwind 4's stock `--container-*` scale (3xs → 7xl, 13 steps) as a new `@theme` overlay in the design-system. Closes #82.

Without this namespace, Tailwind 4 falls through to `--spacing-*` when resolving `max-w-*` / `min-w-*` utilities, producing 16px-wide containers for `max-w-md` and similar — the latent class of bugs surfaced concretely by isnad-graph #889 / PR #903 (`AuthCallbackPage` error card collapsed to ~16px).

## Changes

- **New**: `src/tokens/container.css` — `@theme` block with all 13 `--container-*` tokens
- **Modified**: `src/tokens/index.css` — barrel import for `container.css`
- **Modified**: `src/tokens/index.ts` — adds `container` TS export and includes it in aggregate `tokens` object
- **Modified**: `src/__tests__/tokens.test.ts` — parity test for the new `container` export

Tokens added (Tailwind 4 stock scale):

```
--container-3xs: 16rem    --container-md:  28rem    --container-3xl: 48rem
--container-2xs: 18rem    --container-lg:  32rem    --container-4xl: 56rem
--container-xs:  20rem    --container-xl:  36rem    --container-5xl: 64rem
--container-sm:  24rem    --container-2xl: 42rem    --container-6xl: 72rem
                                                    --container-7xl: 80rem
```

## Build verification (live-trace)

Before:

```
$ grep -c "container-\|--container" dist/styles.css
(no dist/ — pre-existing; produces 0 entries when built from W11 base)
```

After:

```
$ npm run build
✓ built in 2.49s
$ grep -o '\-\-container-[a-z0-9]*' dist/styles.css | sort -u | wc -l
13
$ grep -o '\-\-container-[a-z0-9]*' dist/styles.css | sort -u
--container-2xl  --container-3xs  --container-5xl  --container-md
--container-2xs  --container-4xl  --container-6xl  --container-sm
--container-3xl  --container-7xl  --container-lg   --container-xl
                                  --container-xs
```

`npm run check` (lint + typecheck + test): clean — 68/68 tests pass, typecheck OK, only pre-existing react-refresh warnings unrelated to this change.

## Coordination note

This change unblocks downstream consumer fixes (isnad-graph #889 root cause, ~11 latent `max-w-*` usages across LoginPage, AuthCallbackPage, NarratorDetailPage, HadithDetailPage, CollectionDetailPage, SearchPage) but **does not itself bump the package version**. Consumers will not pick up the new tokens until DS#81 (publish-pipeline verification after DS#57-followup) lands and a release is cut.

## Tech Debt

This PR closes a tech-debt issue (#82, labeled `tech-debt`). No new tech debt introduced.

## Reviewers

- Primary: @Keanu Tama (Architect, design-system) — token namespace authority
- Secondary: (TBD on PR-open — cross-team isnad-graph frontend reviewer, Mei or Linh, via team-lead → isnad-graph-nadia)

## Test plan

- [x] `npm run build` succeeds and emits all 13 `--container-*` tokens in `dist/styles.css`
- [x] `npm run check` passes (lint + typecheck + 68/68 tests)
- [x] New `container` TS export parity-tested against CSS scale
- [ ] Consumer-side: post-publish, isnad-graph rebuild resolves `max-w-md` to `28rem` instead of `1rem` (validated by cross-team reviewer)

