### PR TITLE
docs(claude-md): add cross-repo session-team disclaimer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,12 @@ Copy `.env.example` to `.env` if needed. This package has minimal environment co
 
 ## Team Workflow
 
+> **Cross-repo session-team note:** The team structure described below is the **per-repo team** — operative when a session is opened isolated in this repo for repo-only work.
+>
+> When work is orchestrated from the parent `noorinalabs-main` (the common case — wave kickoff, cross-repo features, wave-coordinated bug fixes), all spawned agents — regardless of which repo they edit — join the single `noorinalabs` session team. The per-repo roster below still governs **commit identity, domain ownership, and reviewer pairing**, but the team-creation surface lives in the orchestrator session, not here.
+>
+> See `noorinalabs-main/CLAUDE.md` § "Session team architecture" and `noorinalabs-main/.claude/team/charter/agents.md` § "Single-Leader Constraint" for the delegation pattern.
+
 **All work MUST be executed through the simulated team structure.** No work begins without spawning the team.
 
 > **Note:** The authoritative team config (charter, roster, hooks, skills) lives in the parent repo (`noorinalabs-main/.claude/`). This repo retains a local copy for agents working within noorinalabs-design-system.


### PR DESCRIPTION
Tracked by noorinalabs/noorinalabs-main#255

Sweep: byte-identical-additions across 6 child repos per main#255. Verify: `git show <pr-head>:CLAUDE.md | grep -A 5 'Cross-repo session-team note'`

## Reviewers

> **Reviewers (2-distinct per charter):** Maeve Callahan (manager), Keanu Tama (architect).
>
> This is one of 6 parallel cross-repo CLAUDE.md PRs implementing noorinalabs/noorinalabs-main#255. Disclaimer block is byte-identical across all 6 PRs (790-byte insertion at `## Team Workflow` anchor, sha256 `5a3fcf87...`). Each PR carries standard 2-reviewer gating per `pull-requests.md` (W11 retro will revisit whether parallel-doc-sweep PRs should formalize a doc-sweep exception going forward).

TechDebt: none