### PR TITLE
ci(P3W15): pin docs.yml actionlint installer to v1.7.12 + SHA256 verify (Refs #578)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -158,6 +158,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Download and verify actionlint
+        env:
+          # Pinned: version + linux_amd64 tarball SHA256 from upstream's
+          # signed release manifest (actionlint_1.7.12_checksums.txt at
+          # https://github.com/rhysd/actionlint/releases/tag/v1.7.12).
+          # `sha256sum -c` aborts the job on mismatch — bytes-on-runner are
+          # exactly what was published at release time. Replaces the prior
+          # `curl|bash` of the unpinned download-actionlint.bash off `main`
+          # (#578): fetching+executing latest-of-main each run is a
+          # supply-chain gap and diverges from the pinned v1.7.12 the
+          # .pre-commit-config.yaml mirror already ships.
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          cd "$RUNNER_TEMP"
+          curl --fail --silent --show-error --location \
+            -o "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint -version
       - name: Run actionlint on workflows
         # shellcheck is preinstalled on ubuntu-latest, so actionlint's embedded
         # shellcheck integration runs (per the actionlint-needs-shellcheck
@@ -170,9 +192,7 @@ jobs:
         # constant `false`; suppress only that exact message so every other
         # check (including on this docs.yml) still gates. Re-enabling the deploy
         # job removes the constant and this ignore becomes a no-op.
-        run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color -ignore 'constant expression "false" in condition'
+        run: actionlint -color -ignore 'constant expression "false" in condition'
 
   precommit-ci-sync:
     name: Pre-commit ⇄ CI sync-drift gate


### PR DESCRIPTION
## Summary

design-system child slice of the org-wide #578 rollout: pin docs.yml's actionlint installer to **v1.7.12** with a **SHA256 verify**, replacing the unpinned `bash <(curl ... download-actionlint.bash)` off `main`.

Canonical two-step form (matches parent `noorinalabs-main` docs.yml@main / PR #579):
1. **Download and verify actionlint** — pinned `ACTIONLINT_VERSION=1.7.12` + `ACTIONLINT_SHA256`, `sha256sum -c` aborts the job on mismatch, install to `/usr/local/bin`.
2. **Run actionlint on workflows** — drops the `./` prefix (binary now on PATH); **PRESERVES** this repo's `-ignore 'constant expression "false" in condition'` flag and its header comment (covers storybook.yml's intentional `if: false` deploy job — out of #578's scope).

## Why

Fetching + executing latest-of-`main` on every run is a supply-chain gap and diverged from the pinned v1.7.12 that `.pre-commit-config.yaml` already ships. This aligns CI with the local mirror.

## SHA256 independently re-verified

`8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8`

Before committing I downloaded the **real** `actionlint_1.7.12_linux_amd64.tar.gz` and confirmed its bytes hash matches both:
- upstream's published `actionlint_1.7.12_checksums.txt` → `sha256sum -c` reports `OK`
- the pinned value in the workflow

(per the verify-third-party-integrity discipline — not just trusting the spec.)

## No required-status-check context change

The `actionlint:` job has no matrix/strategy and keeps its name **"Config — Workflow actionlint"** (one check-run). Only the installer step inside the job changed — no new context, no rename. Compatible with the org-wide ruleset apply this wave.

## Verification

- Pinned v1.7.12 binary runs **clean over all workflows** with the preserved `-ignore` (exit 0); shellcheck 0.10.0 present so actionlint's embedded shellcheck integration actually ran (per actionlint-needs-shellcheck)
- `python3 scripts/pre_commit_ci_sync.py .` → `OK: pre-commit config mirrors all CI-enforced checks`
- docs.yml YAML valid
- statusCheckRollup checked post-push (below)

Refs #578.

## Reviewers

Maricel Reyes (peer) + Luciana Ferreyra (QA). Two charter-format Approved verdicts before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
