### PR TITLE
ci(#520): recover publish.yml push-triggers + CONTRIBUTING + auto-close (ds#77/#80)

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,35 @@
+name: Auto-close issues
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Close referenced issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const matches = body.matchAll(/[Cc]loses?\s+#(\d+)/g);
+            for (const match of matches) {
+              const issue_number = parseInt(match[1]);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                state: 'closed',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body: `Closed by PR #${context.payload.pull_request.number} merged into \`${context.payload.pull_request.base.ref}\`.`,
+              });
+            }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,11 @@
 name: Publish to GitHub Packages
 
 on:
+  push:
+    branches:
+      - main
+      - 'deployments/**'
+    tags: ['v*']
   release:
     types: [published]
 
@@ -31,7 +36,23 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Check if version already published
+        id: version_check
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
+          if npm view "@noorinalabs/design-system@$PKG_VERSION" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "Version $PKG_VERSION already published — skipping publish step."
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "Version $PKG_VERSION not yet on registry — will publish."
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish
+        if: steps.version_check.outputs.already_published == 'false'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to `@noorinalabs/design-system`
+
+## Versioning convention
+
+This package follows [Semantic Versioning](https://semver.org/):
+
+- **PATCH** (`0.0.X`): bug fixes, internal refactors, dependency bumps that do not change the public API.
+- **MINOR** (`0.X.0`): new components, tokens, icons, or props added in a backward-compatible way.
+- **MAJOR** (`X.0.0`): breaking changes — renamed/removed components, changed prop signatures, or token contract changes.
+
+While the package is at `0.x.x`, MINOR bumps may include narrow breaking changes per SemVer 0.x conventions; document any such break in the PR description and the changelog entry.
+
+### When to bump
+
+Every PR that changes runtime behavior, exported API, or published assets MUST bump the version in `package.json` as part of the PR. Reviewers should reject PRs that change behavior without a version bump.
+
+PRs that touch only the following do NOT require a version bump:
+
+- Tests (`*.test.{ts,tsx}`, `*.spec.{ts,tsx}`)
+- Storybook stories (`*.stories.{ts,tsx,mdx}`)
+- Documentation (`README.md`, `docs/**`, this file)
+- CI/workflow configuration (`.github/**`)
+- Internal tooling (`scripts/**`, `.eslintrc`, `prettier.config.*`)
+
+### Publish trigger
+
+`@noorinalabs/design-system` publishes to the GitHub Packages npm registry via `.github/workflows/publish.yml`. The workflow fires on:
+
+1. **Push to `main`** — auto-publishes whatever version is in `package.json`. If the version already exists on the registry, the publish step is skipped (no failure). This means a merge to `main` without a version bump is a no-op publish, by design.
+2. **Push to `deployments/**`** (wave branches) — publishes wave pre-releases for cross-repo consumers. See "Wave-branch pre-releases" below.
+3. **Tag push matching `v*`** (e.g., `git tag v0.0.4 && git push --tags`) — same publish path, marked semantically as a release.
+4. **Release published** — kept for backward compatibility with the original tag-and-release flow.
+
+For most PRs the push-to-main trigger is sufficient. Use tagged releases for milestones that consumers should pin against.
+
+### Wave-branch pre-releases
+
+Cross-repo wave work (Phase 3 wave-10 and forward) sometimes needs consumers in sibling repos to depend on an unreleased design-system change before the wave branch merges to `main`. To support that, wave branches under `deployments/**` are allowed to publish **pre-release** semver versions to GitHub Packages.
+
+**Pre-release version format:** `<X.Y.Z>-wave<N>.<patch>` where:
+
+- `<X.Y.Z>` is the SemVer base — the version that will become canonical once this wave merges to `main`.
+- `<N>` is the wave number (e.g., `10` for `deployments/phase-3/wave-10`).
+- `<patch>` increments per re-cut on the same wave branch, starting at `0` (e.g., `0.0.3-wave10.0`, `0.0.3-wave10.1` if a follow-up fix is required mid-wave).
+
+**Rules:**
+
+- The main-branch publish remains the **canonical release**. Pre-releases are time-bounded by their wave's lifespan and exist to unblock cross-repo integration during the wave, not to ship to end users.
+- Consumers depending on a wave pre-release MUST pin the exact version (e.g., `"@noorinalabs/design-system": "0.0.3-wave10.0"`) — SemVer range matchers do not auto-include pre-release versions, which is the desired behavior here.
+- When the wave branch merges to `main`, bump the version in the merge to the canonical `<X.Y.Z>` (drop the `-wave<N>.<patch>` suffix) and let the main-branch publish trigger ship the canonical release. Consumers should then move their pin to the canonical version in a follow-up PR.
+- A wave branch may publish multiple `<patch>` increments during its lifespan; each must bump the suffix patch number to avoid registry collision (the `npm view` guard would otherwise skip the re-publish).
+
+## Consumer migration
+
+Consumers install this package from GitHub Packages. They need:
+
+1. `.npmrc` at the repo root containing:
+   ```
+   @noorinalabs:registry=https://npm.pkg.github.com
+   ```
+2. A `NODE_AUTH_TOKEN` environment variable with at least `read:packages` scope during `npm ci`. In CI this can be `${{ secrets.GITHUB_TOKEN }}` if the workflow has `packages: read` permission.
+3. In Dockerfiles, pass the token via `--build-arg` from the CI workflow and set it as `NODE_AUTH_TOKEN` for the install step.
+
+For local development, contributors need a personal access token with `read:packages` scope in `~/.npmrc`:
+
+```
+//npm.pkg.github.com/:_authToken=ghp_xxx
+```
+
+## Pull request workflow
+
+Follow the noorinalabs charter conventions:
+
+- Feature branches named `{FirstInitial}.{LastName}/{IIII}-{slug}`
+- Two reviewers per PR (Approved verdict required)
+- No `--no-verify` on commits
+- Commit identity via per-commit `-c` flags (`git -c user.name="..." -c user.email="parametrization+First.Last@gmail.com" commit -F /tmp/<file>.md`)


### PR DESCRIPTION
## Summary

Recovers CI/release content stranded on `deployments/phase-3/wave-10` that never reached `main`.

- **`.github/workflows/publish.yml`** — adds push triggers (`main`, `deployments/**`, tags `v*`) and the idempotent "version already published" guard from ds#77 (0c8cd2e) + ds#80 (14ce683). Applied onto main's current publish.yml: Node 22.x (from #74/#75), the `https://npm.pkg.github.com` GitHub Packages registry, and `NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}` are all preserved — only the triggers and guard are added. The recovered guard already targets the same `npm.pkg.github.com` registry main uses, so it is compatible with main's current registry/auth setup.
- **`CONTRIBUTING.md`** (new, ds#80) — semver / pre-release / wave-branch publish documentation.
- **`.github/workflows/auto-close-issues.yml`** (new, 65eb730, owner-approved org-wide) — closes `Closes #N`-referenced issues on PR merge.

The wave-10 `0.0.4-wave10.0` version string was deliberately **not** brought over — `main` stays at `0.0.2`; version bumps happen at release time per CONTRIBUTING.

## Validation

- `actionlint` clean on both `publish.yml` and `auto-close-issues.yml`
- `npm ci && npm run build && npm run test` green (68 tests), `npx prettier --check src/` clean

Refs noorinalabs-main#520
Recovers ds#77/#80 (stranded on wave-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
