### PR TITLE
feat(#520): recover icon-extraction refactor (ds#79)

### DIFF
--- a/src/__tests__/icons.test.tsx
+++ b/src/__tests__/icons.test.tsx
@@ -10,6 +10,10 @@ import { CompareIcon } from '../icons/compare-icon'
 import { GraphExplorerIcon } from '../icons/graph-explorer-icon'
 import { TimelineIcon } from '../icons/timeline-icon'
 import { SignOutIcon } from '../icons/sign-out-icon'
+import { CloseIcon } from '../icons/close-icon'
+import { CheckIcon } from '../icons/check-icon'
+import { RadioDotIcon } from '../icons/radio-dot-icon'
+import { ChevronRightIcon } from '../icons/chevron-right-icon'
 import { GeometricBorder } from '../icons/geometric-border'
 import { OctagonalFrame } from '../icons/octagonal-frame'
 import { PageHeaderAccent } from '../icons/page-header-accent'
@@ -105,6 +109,44 @@ describe('SignOutIcon', () => {
   it('renders without crashing', () => {
     const { container } = render(<SignOutIcon />)
     expect(container.querySelector('svg')).toBeDefined()
+  })
+})
+
+describe('CloseIcon', () => {
+  it('renders an SVG with stroke-based paths', () => {
+    const { container } = render(<CloseIcon />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeDefined()
+    expect(svg?.getAttribute('stroke')).toBe('currentColor')
+    expect(svg?.getAttribute('aria-hidden')).toBe('true')
+  })
+})
+
+describe('CheckIcon', () => {
+  it('renders an SVG with stroke-based path', () => {
+    const { container } = render(<CheckIcon />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeDefined()
+    expect(svg?.getAttribute('stroke')).toBe('currentColor')
+  })
+})
+
+describe('RadioDotIcon', () => {
+  it('renders a filled circle', () => {
+    const { container } = render(<RadioDotIcon />)
+    const circle = container.querySelector('circle')
+    expect(circle).toBeDefined()
+    expect(circle?.getAttribute('fill')).toBe('currentColor')
+    expect(circle?.getAttribute('stroke')).toBe('none')
+  })
+})
+
+describe('ChevronRightIcon', () => {
+  it('renders an SVG with stroke-based path', () => {
+    const { container } = render(<ChevronRightIcon />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeDefined()
+    expect(svg?.getAttribute('stroke')).toBe('currentColor')
   })
 })
 

--- a/src/components/dropdown-menu.tsx
+++ b/src/components/dropdown-menu.tsx
@@ -1,5 +1,8 @@
 import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react'
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { CheckIcon } from '../icons/check-icon'
+import { ChevronRightIcon } from '../icons/chevron-right-icon'
+import { RadioDotIcon } from '../icons/radio-dot-icon'
 import { cn } from '../utils/cn'
 
 const DropdownMenu = DropdownMenuPrimitive.Root
@@ -67,20 +70,7 @@ const DropdownMenuCheckboxItem = forwardRef<
   >
     <span className="absolute start-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M20 6 9 17l-5-5" />
-        </svg>
+        <CheckIcon size={16} />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -105,15 +95,7 @@ const DropdownMenuRadioItem = forwardRef<
   >
     <span className="absolute start-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="8"
-          height="8"
-          viewBox="0 0 8 8"
-          aria-hidden="true"
-        >
-          <circle cx="4" cy="4" r="4" fill="currentColor" />
-        </svg>
+        <RadioDotIcon size={8} />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -161,21 +143,7 @@ const DropdownMenuSubTrigger = forwardRef<
     {...props}
   >
     {children}
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="ms-auto"
-      aria-hidden="true"
-    >
-      <path d="m9 18 6-6-6-6" />
-    </svg>
+    <ChevronRightIcon size={16} className="ms-auto" />
   </DropdownMenuPrimitive.SubTrigger>
 ))
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName

--- a/src/components/toast.tsx
+++ b/src/components/toast.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react'
 import * as ToastPrimitive from '@radix-ui/react-toast'
 import { cva, type VariantProps } from 'class-variance-authority'
+import { CloseIcon } from '../icons/close-icon'
 import { cn } from '../utils/cn'
 
 const ToastProvider = ToastPrimitive.Provider
@@ -92,21 +93,7 @@ const ToastClose = forwardRef<
     toast-close=""
     {...props}
   >
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M18 6 6 18" />
-      <path d="m6 6 12 12" />
-    </svg>
+    <CloseIcon size={16} />
   </ToastPrimitive.Close>
 ))
 ToastClose.displayName = ToastPrimitive.Close.displayName

--- a/src/icons/check-icon.tsx
+++ b/src/icons/check-icon.tsx
@@ -1,0 +1,11 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Check — confirmation glyph for checkbox indicators, success states, and selected items */
+export function CheckIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M20 6 9 17l-5-5" />
+    </IconBase>
+  )
+}

--- a/src/icons/chevron-right-icon.tsx
+++ b/src/icons/chevron-right-icon.tsx
@@ -1,0 +1,11 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** ChevronRight — directional glyph for sub-menu triggers and expandable rows */
+export function ChevronRightIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="m9 18 6-6-6-6" />
+    </IconBase>
+  )
+}

--- a/src/icons/close-icon.tsx
+++ b/src/icons/close-icon.tsx
@@ -1,0 +1,12 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** Close — X / dismiss glyph for modals, toasts, and dismissible chips */
+export function CloseIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </IconBase>
+  )
+}

--- a/src/icons/icons.stories.tsx
+++ b/src/icons/icons.stories.tsx
@@ -16,6 +16,10 @@ import {
   GeometricBorder,
   OctagonalFrame,
   PageHeaderAccent,
+  CloseIcon,
+  CheckIcon,
+  RadioDotIcon,
+  ChevronRightIcon,
 } from './index'
 import type { IconProps } from './types'
 
@@ -29,6 +33,10 @@ const icons = [
   { name: 'GraphExplorerIcon', Component: GraphExplorerIcon },
   { name: 'AdminIcon', Component: AdminIcon },
   { name: 'SignOutIcon', Component: SignOutIcon },
+  { name: 'CloseIcon', Component: CloseIcon },
+  { name: 'CheckIcon', Component: CheckIcon },
+  { name: 'RadioDotIcon', Component: RadioDotIcon },
+  { name: 'ChevronRightIcon', Component: ChevronRightIcon },
 ]
 
 function IconGallery(props: IconProps) {

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -26,3 +26,9 @@ export { EmptyState } from './empty-state'
 export { GeometricBorder } from './geometric-border'
 export { OctagonalFrame } from './octagonal-frame'
 export { PageHeaderAccent } from './page-header-accent'
+
+// Utility / interaction icons (used internally by components, also exported for consumers)
+export { CloseIcon } from './close-icon'
+export { CheckIcon } from './check-icon'
+export { RadioDotIcon } from './radio-dot-icon'
+export { ChevronRightIcon } from './chevron-right-icon'

--- a/src/icons/radio-dot-icon.tsx
+++ b/src/icons/radio-dot-icon.tsx
@@ -1,0 +1,11 @@
+import type { IconProps } from './types'
+import { IconBase } from './icon-base'
+
+/** RadioDot — filled dot indicator for radio item selection */
+export function RadioDotIcon(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <circle cx="12" cy="12" r="12" fill="currentColor" stroke="none" />
+    </IconBase>
+  )
+}


### PR DESCRIPTION
## Summary

Recovers the DS#53/#79 icon-extraction refactor stranded on `deployments/phase-3/wave-10` (commits 1ba2970 + 9ceab42).

- **New icon components** in `src/icons/`: `CloseIcon`, `CheckIcon`, `RadioDotIcon`, `ChevronRightIcon` — all built on `IconBase` (24×24 viewBox, 1.5px stroke, `currentColor`, `aria-hidden`). `RadioDotIcon` uses the `fill="currentColor" stroke="none"` override and the `r=12` radius fix from Maricel's #79 review (9ceab42).
- **`toast.tsx`** — `ToastClose` inline `<svg>` → `<CloseIcon size={16} />`.
- **`dropdown-menu.tsx`** — checkbox indicator → `CheckIcon`, radio indicator → `RadioDotIcon` (size 8), sub-trigger chevron → `ChevronRightIcon`. The replaced inline SVGs used `strokeWidth="2"`; the icon components inherit the Qalam-standard 1.5px stroke from `IconBase` — the intended drift cleanup.
- **`index.ts`** — exports the 4 new icons.
- **`icons.stories.tsx`** — adds the 4 icons to the gallery.
- **`icons.test.tsx`** — 4 new describe blocks (stroke / fill / aria semantics).

The refactor was **hand-applied onto main's current W15 prettier-reformatted** `toast.tsx` / `dropdown-menu.tsx` (#91/#93), not copied from the wave-10 double-quote source, so it passes the W15 prettier CI gate. No version bump — `main` stays at `0.0.2`; bumps happen at release time.

## Validation

Local gates all green:
- `npm run lint` — 0 errors (3 pre-existing `react-refresh` warnings)
- `npm run typecheck` — clean
- `npm run build` — dist generated
- `npm run test` — 72 pass (icons.test 19 → 23)
- `npx prettier --check src/` — clean
- `npx vitest run --coverage` — runs

Refs noorinalabs-main#520
Recovers ds#79 (stranded on wave-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
