### PR TITLE
tech-debt(#322): reconcile ruleset-main.json context ci → ci (20.x)

### DIFF
--- a/.github/branch-protection/SPEC.md
+++ b/.github/branch-protection/SPEC.md
@@ -48,8 +48,8 @@ A **repository ruleset** targeting `~DEFAULT_BRANCH`, `enforcement: active`:
 
   | Context | Source job |
   |---------|-----------|
-  | `ci` | `ci.yml` → `ci` (eslint + prettier format-check + tsc + vite build + vitest) |
-  | `validate-package` | `ci.yml` → `validate-package` (pack contents + exports resolution) |
+  | `ci (20.x)` | `ci.yml` → `ci` (eslint + prettier format-check + tsc + vite build + vitest). The job has a `matrix: node-version: [20.x]`, so its check-run name is **matrix-expanded** to `ci (20.x)` — the bare `ci` context would never report and would deadlock every merge. |
+  | `validate-package` | `ci.yml` → `validate-package` (pack contents + exports resolution). No matrix, so the check-run name is the bare job name. |
 
   The `docs.yml` jobs added in W14 — including `precommit-ci-sync` (the
   Pre-commit ⇄ CI sync-drift gate) and the docs/config gates (`markdownlint`,

--- a/.github/branch-protection/ruleset-main.json
+++ b/.github/branch-protection/ruleset-main.json
@@ -36,7 +36,7 @@
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "ci" },
+          { "context": "ci (20.x)" },
           { "context": "validate-package" }
         ]
       }


### PR DESCRIPTION
## Summary

Reconciles the committed `.github/branch-protection/ruleset-main.json` with the live ruleset (id 17139787) applied + verified at origin during P3W15.

The committed JSON declared required status check context `ci`, but the `ci` job in `ci.yml` carries `matrix: node-version: [20.x]`, so its check-run name is **matrix-expanded** to `ci (20.x)`. A bare `ci` context never reports green → a future idempotent `apply-ruleset.sh` re-run (PUT update path) would overwrite the correct live ruleset and **deadlock every merge**.

Changes:
- `ruleset-main.json`: `{ "context": "ci" }` → `{ "context": "ci (20.x)" }`
- `SPEC.md`: document the matrix-expansion of the `ci` check-run name in the required-status-checks context table.

The `validate-package` context was already correct (no matrix on that job).

## Test Plan

- [x] JSON parses; `required_status_checks` now `[{ "context": "ci (20.x)" }, { "context": "validate-package" }]`.
- [x] Round-trip verified: committed payload matches live ruleset 17139787 **exactly** across all blocks — `required_status_checks`, `pull_request` params, `bypass_actors`, `conditions`, and rule-type set (`deletion`, `non_fast_forward`, `pull_request`, `required_status_checks`).
- [x] `gh api .../commits/main/check-runs` confirms the live check-run name is `ci (20.x)` (matrix-expanded), not bare `ci`.
- [x] `DRY_RUN=1 ./apply-ruleset.sh` shows an idempotent **UPDATE ruleset 17139787** with the corrected context (no regression).

Closes #94

Co-Authored-By: Keanu Tama <parametrization+Keanu.Tama@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
