### PR TITLE
ci: enable Storybook GitHub Pages deploy (#54)

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -3,6 +3,11 @@ name: Deploy Storybook
 on:
   push:
     branches: [main]
+    paths:
+      - "src/**"
+      - ".storybook/**"
+      - "package.json"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -30,13 +35,6 @@ jobs:
 
   deploy:
     needs: build
-    # Disabled until GitHub Pages is configured for this repo. The deploy
-    # step has been failing on every main push with `404 Failed to create
-    # deployment... Ensure GitHub Pages has been enabled` because Pages
-    # was never turned on. Enabling it is a publishing decision (Storybook
-    # would become public on github.io) and is owned by the project lead,
-    # not a CI hygiene fix. See follow-up issue for tracking.
-    if: false
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

Enables automated Storybook publishing to GitHub Pages by re-enabling the `deploy` job in `.github/workflows/storybook.yml`, plus scoping triggers.

**Key finding:** ds#54 asked to *configure* Pages publishing, but the workflow (`storybook.yml`) already existed with a complete, modern Pages pipeline (`actions/upload-pages-artifact` + `actions/deploy-pages`, `pages: write` + `id-token: write` perms). The only blocker was the `deploy` job being gated `if: false` (paper-over from PR #56) because Pages was never enabled — the deploy step 404'd on every main push.

**Pages is now enabled.** Verified via `gh api repos/noorinalabs/noorinalabs-design-system/pages`:
```
build_type: "workflow", public: true, https_enforced: true,
html_url: "https://noorinalabs.github.io/noorinalabs-design-system/"
```
This is the publishing decision (option a) the owner flagged in #54, and the owner's first issue comment names "re-enable as an explicit acceptance criterion." So no further owner action is required for Pages enablement — it's already done.

## Changes
- Remove `if: false` + obsolete disable comment on the `deploy` job — restores actual publishing.
- Add `paths:` filter to the push trigger: `src/**`, `.storybook/**`, `package.json` (per scope).
- Add `workflow_dispatch:` for manual runs.
- Trigger stays `main` + dispatch only → pre-commit⇄CI sync-drift gate unaffected (verified).

## Test Plan
- [x] `actionlint .github/workflows/storybook.yml` → clean (shellcheck on PATH, full integration).
- [x] `python3 scripts/pre_commit_ci_sync.py .` → "OK: pre-commit config mirrors all CI-enforced checks."
- [x] `npm ci && npm run build:storybook` → valid `storybook-static/` artifact (iframe.html, assets, components, icons).
- [ ] Post-merge: confirm the Deploy Storybook run's `deploy` job succeeds (not skipped) and the page resolves at https://noorinalabs.github.io/noorinalabs-design-system/ — runtime-gated, needs the merge to main to fire the push trigger.

## Owner-action items
- None for Pages enablement (already on). Post-merge live-verify is a Test Plan item, not an owner gate.

Closes #54
