### PR TITLE
feat(tokens): categorical/data-viz color palette (#102)

### DIFF
--- a/docs/brand/color-palette.md
+++ b/docs/brand/color-palette.md
@@ -106,6 +106,68 @@ Domain-specific grading colors (sahih/hasan/daif/mawdu) always include text labe
 
 ---
 
+## Categorical / Data-Visualization Palette
+
+A **qualitative** scale for graph and chart **series** — community/cluster coloring in the isnad-graph `ForceGraph`, comparative views, and timelines. Unlike the semantic and domain colors above, these carry **no inherent meaning**: they exist only to keep adjacent series mutually distinguishable. Index assignment (series 1, 2, 3, …) is positional and stable, so a given cluster keeps its color across renders.
+
+Design constraints:
+
+- **10 series**, hues spread around the wheel with deliberate **lightness variation** so the scale survives the three common forms of color-vision deficiency (CVD), not hue alone.
+- Each series meets **WCAG 2.2 §1.4.11 non-text contrast (≥3:1)** against its mode's `--color-background`, so a filled node/marker reads against the canvas. (Series marks are graphical objects; pair them with labels/legends — never rely on series color alone to convey identity.)
+- A separate **accent** token (`--color-viz-accent`) for the active/selected edge or focused-node ring.
+- Light and dark variants follow the same lighten-for-dark strategy as the rest of the system.
+
+### Light Mode (on Parchment `#f5f0e8`)
+
+| Token | OKLCH | Hex | Contrast vs bg |
+|-------|-------|-----|----------------|
+| `--color-viz-categorical-1` | `oklch(0.58 0.15 35)` | `#c25237` | 4.08:1 |
+| `--color-viz-categorical-2` | `oklch(0.6 0.135 75)` | `#ae7200` | 3.59:1 |
+| `--color-viz-categorical-3` | `oklch(0.62 0.12 120)` | `#7d9034` | 3.15:1 |
+| `--color-viz-categorical-4` | `oklch(0.55 0.11 155)` | `#318454` | 4.10:1 |
+| `--color-viz-categorical-5` | `oklch(0.58 0.1 195)` | `#008c8d` | 3.63:1 |
+| `--color-viz-categorical-6` | `oklch(0.52 0.13 245)` | `#036eae` | 4.86:1 |
+| `--color-viz-categorical-7` | `oklch(0.48 0.14 275)` | `#4953ab` | 6.05:1 |
+| `--color-viz-categorical-8` | `oklch(0.52 0.15 310)` | `#834ba8` | 5.28:1 |
+| `--color-viz-categorical-9` | `oklch(0.55 0.16 345)` | `#af4387` | 4.72:1 |
+| `--color-viz-categorical-10` | `oklch(0.5 0.17 15)` | `#af2843` | 5.86:1 |
+| `--color-viz-accent` | `oklch(0.55 0.18 255)` | `#026fd7` | 4.39:1 |
+
+### Dark Mode (on Charcoal `#1a1f28`)
+
+| Token | OKLCH | Hex | Contrast vs bg |
+|-------|-------|-----|----------------|
+| `--color-viz-categorical-1` | `oklch(0.72 0.13 35)` | `#ea856b` | 6.94:1 |
+| `--color-viz-categorical-2` | `oklch(0.78 0.12 75)` | `#e4ac59` | 8.91:1 |
+| `--color-viz-categorical-3` | `oklch(0.75 0.11 120)` | `#a5b866` | 8.34:1 |
+| `--color-viz-categorical-4` | `oklch(0.7 0.1 155)` | `#69b183` | 7.08:1 |
+| `--color-viz-categorical-5` | `oklch(0.72 0.09 195)` | `#57b6b6` | 7.58:1 |
+| `--color-viz-categorical-6` | `oklch(0.68 0.12 245)` | `#519fdd` | 6.35:1 |
+| `--color-viz-categorical-7` | `oklch(0.66 0.13 275)` | `#7c8ae1` | 5.68:1 |
+| `--color-viz-categorical-8` | `oklch(0.7 0.13 310)` | `#b786db` | 6.43:1 |
+| `--color-viz-categorical-9` | `oklch(0.72 0.14 345)` | `#e17eb9` | 6.82:1 |
+| `--color-viz-categorical-10` | `oklch(0.68 0.15 15)` | `#e56d7a` | 5.85:1 |
+| `--color-viz-accent` | `oklch(0.7 0.15 255)` | `#59a0f9` | 6.76:1 |
+
+> Contrast ratios computed via OKLCH→sRGB conversion against the mode's `--color-background`. All series clear the 3:1 non-text-contrast bar; the accent additionally clears 4.5:1 (text-level AA) in both modes.
+
+### Consuming the palette
+
+These tokens are exported both ways, matching the rest of the system:
+
+- **CSS custom properties** — `--color-viz-categorical-1` … `--color-viz-categorical-10` and `--color-viz-accent`. They are **theme-reactive**: they resolve to the light or dark value automatically under `prefers-color-scheme` or a `[data-theme]` toggle. A canvas renderer that cannot use `var()` directly should read the resolved value with `getComputedStyle(document.documentElement).getPropertyValue('--color-viz-categorical-' + n)`, mirroring how `ForceGraph` already reads its theme colors. This keeps the graph in step with light/dark mode.
+- **TypeScript constants** — `dataViz` (light) and `dataVizDark` (dark) from `@noorinalabs/design-system/tokens`, each `{ categorical: string[], accent: string }`. Use these for libraries that take a static color array. Note they are **not** theme-reactive — prefer the CSS vars when the view must follow the active theme.
+
+```ts
+import { dataViz } from '@noorinalabs/design-system/tokens'
+
+const seriesColor = (i: number) => dataViz.categorical[i % dataViz.categorical.length]
+```
+
+This palette is the agreed source for **isnad-graph#979** (deriving `ForceGraph` community colors + accent from DS tokens), replacing the bespoke hardcoded `COMMUNITY_HEX` array and `ACCENT`.
+
+---
+
 ## Usage Guidelines
 
 ### Do

--- a/src/__tests__/tokens.test.ts
+++ b/src/__tests__/tokens.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   colors,
   colorsDark,
+  dataViz,
+  dataVizDark,
   fontFamily,
   fontSize,
   fontWeight,
@@ -40,6 +42,23 @@ describe('design tokens', () => {
     expect(colors.sunni).toBeTruthy()
     expect(colors.shia).toBeTruthy()
     expect(colors.tierThiqah).toBeTruthy()
+  })
+
+  it('exports a categorical data-viz palette (light + dark) with an accent', () => {
+    expect(dataViz.categorical).toHaveLength(10)
+    expect(dataVizDark.categorical).toHaveLength(dataViz.categorical.length)
+    for (const c of [...dataViz.categorical, ...dataVizDark.categorical]) {
+      expect(c).toMatch(/^oklch\(/)
+    }
+    expect(dataViz.accent).toBeTruthy()
+    expect(dataVizDark.accent).toBeTruthy()
+  })
+
+  it('keeps the categorical series perceptually distinct (unique hues)', () => {
+    const hueOf = (c: string) => Number(c.match(/oklch\([\d.]+ [\d.]+ ([\d.]+)\)/)?.[1])
+    const hues = dataViz.categorical.map(hueOf)
+    expect(hues.every((h) => Number.isFinite(h))).toBe(true)
+    expect(new Set(hues).size).toBe(hues.length)
   })
 
   it('exports font family tokens', () => {
@@ -102,6 +121,8 @@ describe('design tokens', () => {
     expect(tokens).toBeDefined()
     expect(tokens.colors).toBe(colors)
     expect(tokens.colorsDark).toBe(colorsDark)
+    expect(tokens.dataViz).toBe(dataViz)
+    expect(tokens.dataVizDark).toBe(dataVizDark)
     expect(tokens.fontFamily).toBe(fontFamily)
     expect(tokens.fontSize).toBe(fontSize)
     expect(tokens.spacing).toBe(spacing)

--- a/src/tokens/colors.css
+++ b/src/tokens/colors.css
@@ -11,6 +11,7 @@
  *   - Domain (hadith grading): sahih, hasan, daif, mawdu
  *   - Domain (sect): sunni, shia
  *   - Domain (narrator reliability): thiqah, saduq, daif-narrator, matruk, kadhdhab
+ *   - Data-viz: categorical series (1..10) + accent (graph/chart qualitative scale)
  */
 
 /* ============================================================
@@ -93,6 +94,24 @@
   --color-tier-matruk-bg: oklch(0.95 0.03 30);
   --color-tier-kadhdhab: oklch(0.5 0.15 15);
   --color-tier-kadhdhab-bg: oklch(0.94 0.03 15);
+
+  /* --- Data-viz: categorical series palette ---
+   * Qualitative scale for graph/chart series (clusters, communities).
+   * Hue-spread + lightness-varied for CVD distinguishability; each series
+   * meets WCAG 2.2 non-text contrast (>=3:1) against --color-background.
+   * Consumed via getComputedStyle by isnad-graph ForceGraph (ig#979). */
+  --color-viz-categorical-1: oklch(0.58 0.15 35);
+  --color-viz-categorical-2: oklch(0.6 0.135 75);
+  --color-viz-categorical-3: oklch(0.62 0.12 120);
+  --color-viz-categorical-4: oklch(0.55 0.11 155);
+  --color-viz-categorical-5: oklch(0.58 0.1 195);
+  --color-viz-categorical-6: oklch(0.52 0.13 245);
+  --color-viz-categorical-7: oklch(0.48 0.14 275);
+  --color-viz-categorical-8: oklch(0.52 0.15 310);
+  --color-viz-categorical-9: oklch(0.55 0.16 345);
+  --color-viz-categorical-10: oklch(0.5 0.17 15);
+  /* Highlight for active/selected edge or focused node ring. */
+  --color-viz-accent: oklch(0.55 0.18 255);
 }
 
 /* ============================================================
@@ -159,6 +178,20 @@
     --color-tier-matruk-bg: oklch(0.25 0.03 30);
     --color-tier-kadhdhab: oklch(0.6 0.14 15);
     --color-tier-kadhdhab-bg: oklch(0.24 0.03 15);
+
+    /* Data-viz: categorical series palette (dark) — lightened for >=3:1
+     * non-text contrast against the dark --color-background. */
+    --color-viz-categorical-1: oklch(0.72 0.13 35);
+    --color-viz-categorical-2: oklch(0.78 0.12 75);
+    --color-viz-categorical-3: oklch(0.75 0.11 120);
+    --color-viz-categorical-4: oklch(0.7 0.1 155);
+    --color-viz-categorical-5: oklch(0.72 0.09 195);
+    --color-viz-categorical-6: oklch(0.68 0.12 245);
+    --color-viz-categorical-7: oklch(0.66 0.13 275);
+    --color-viz-categorical-8: oklch(0.7 0.13 310);
+    --color-viz-categorical-9: oklch(0.72 0.14 345);
+    --color-viz-categorical-10: oklch(0.68 0.15 15);
+    --color-viz-accent: oklch(0.7 0.15 255);
   }
 }
 
@@ -216,6 +249,17 @@
   --color-tier-matruk-bg: oklch(0.25 0.03 30);
   --color-tier-kadhdhab: oklch(0.6 0.14 15);
   --color-tier-kadhdhab-bg: oklch(0.24 0.03 15);
+  --color-viz-categorical-1: oklch(0.72 0.13 35);
+  --color-viz-categorical-2: oklch(0.78 0.12 75);
+  --color-viz-categorical-3: oklch(0.75 0.11 120);
+  --color-viz-categorical-4: oklch(0.7 0.1 155);
+  --color-viz-categorical-5: oklch(0.72 0.09 195);
+  --color-viz-categorical-6: oklch(0.68 0.12 245);
+  --color-viz-categorical-7: oklch(0.66 0.13 275);
+  --color-viz-categorical-8: oklch(0.7 0.13 310);
+  --color-viz-categorical-9: oklch(0.72 0.14 345);
+  --color-viz-categorical-10: oklch(0.68 0.15 15);
+  --color-viz-accent: oklch(0.7 0.15 255);
   color-scheme: dark;
 }
 
@@ -268,5 +312,16 @@
   --color-tier-matruk-bg: oklch(0.95 0.03 30);
   --color-tier-kadhdhab: oklch(0.5 0.15 15);
   --color-tier-kadhdhab-bg: oklch(0.94 0.03 15);
+  --color-viz-categorical-1: oklch(0.58 0.15 35);
+  --color-viz-categorical-2: oklch(0.6 0.135 75);
+  --color-viz-categorical-3: oklch(0.62 0.12 120);
+  --color-viz-categorical-4: oklch(0.55 0.11 155);
+  --color-viz-categorical-5: oklch(0.58 0.1 195);
+  --color-viz-categorical-6: oklch(0.52 0.13 245);
+  --color-viz-categorical-7: oklch(0.48 0.14 275);
+  --color-viz-categorical-8: oklch(0.52 0.15 310);
+  --color-viz-categorical-9: oklch(0.55 0.16 345);
+  --color-viz-categorical-10: oklch(0.5 0.17 15);
+  --color-viz-accent: oklch(0.55 0.18 255);
   color-scheme: light;
 }

--- a/src/tokens/index.ts
+++ b/src/tokens/index.ts
@@ -145,6 +145,52 @@ export const colorsDark = {
 } as const
 
 // ---------------------------------------------------------------------------
+// Data-viz — categorical / qualitative series palette
+//
+// Qualitative scale for graph & chart series (clusters, communities). Hues are
+// spread around the wheel with deliberate lightness variation for CVD
+// distinguishability; each series meets WCAG 2.2 non-text contrast (>=3:1)
+// against the matching-mode `background` token.
+//
+// For theme-reactive consumers (e.g. a canvas reading resolved hex), prefer the
+// CSS custom properties `--color-viz-categorical-{1..10}` / `--color-viz-accent`,
+// which switch with light/dark mode. These constants are the static light- and
+// dark-mode values for libraries that take a color array directly.
+// ---------------------------------------------------------------------------
+
+export const dataViz = {
+  categorical: [
+    'oklch(0.58 0.15 35)',
+    'oklch(0.60 0.135 75)',
+    'oklch(0.62 0.12 120)',
+    'oklch(0.55 0.11 155)',
+    'oklch(0.58 0.10 195)',
+    'oklch(0.52 0.13 245)',
+    'oklch(0.48 0.14 275)',
+    'oklch(0.52 0.15 310)',
+    'oklch(0.55 0.16 345)',
+    'oklch(0.50 0.17 15)',
+  ],
+  accent: 'oklch(0.55 0.18 255)',
+} as const
+
+export const dataVizDark = {
+  categorical: [
+    'oklch(0.72 0.13 35)',
+    'oklch(0.78 0.12 75)',
+    'oklch(0.75 0.11 120)',
+    'oklch(0.70 0.10 155)',
+    'oklch(0.72 0.09 195)',
+    'oklch(0.68 0.12 245)',
+    'oklch(0.66 0.13 275)',
+    'oklch(0.70 0.13 310)',
+    'oklch(0.72 0.14 345)',
+    'oklch(0.68 0.15 15)',
+  ],
+  accent: 'oklch(0.70 0.15 255)',
+} as const
+
+// ---------------------------------------------------------------------------
 // Typography
 // ---------------------------------------------------------------------------
 
@@ -327,6 +373,8 @@ export const borderWidth = {
 export const tokens = {
   colors,
   colorsDark,
+  dataViz,
+  dataVizDark,
   fontFamily,
   fontSize,
   fontWeight,


### PR DESCRIPTION
Closes #102. Unblocks isnad-graph#979 (ig#967 Bucket B).

## What

Adds a **categorical / data-visualization** color palette as first-class Qalam tokens — a qualitative 10-series scale + a highlight accent — exposed **both** as CSS custom properties and TypeScript constants, with light and dark variants, mirroring the existing semantic/domain token pattern.

### Token contract (agreed names for ig#979)

CSS custom properties (theme-reactive — switch with `prefers-color-scheme` / `[data-theme]`):

- `--color-viz-categorical-1` … `--color-viz-categorical-10`
- `--color-viz-accent` (active/selected edge, focused-node ring)

TypeScript constants from `@noorinalabs/design-system/tokens`:

- `dataViz` (light) and `dataVizDark` (dark), each `{ categorical: string[]; accent: string }`, also folded into the aggregate `tokens` object.

### Palette design

| Constraint | How |
|---|---|
| Perceptual distinctness | 10 hues spread around the OKLCH wheel |
| CVD-safe | deliberate **lightness variation** (not hue alone) across series |
| Contrast | every series meets WCAG 2.2 §1.4.11 **non-text contrast ≥3:1** against its mode's `--color-background`; accent additionally clears 4.5:1 (text-level AA) in both modes. Ratios computed via OKLCH→sRGB conversion and tabulated in the doc. |
| Dark mode | series lightened, same strategy as the rest of the system |

## How isnad-graph#979 consumes it

`ForceGraph.tsx` today hardcodes `COMMUNITY_HEX` (8 colors) + `ACCENT`. Canvas can't use `var()`, so it reads resolved hex via `getComputedStyle`. After this lands, ig#979 resolves `--color-viz-categorical-{1..10}` + `--color-viz-accent` the same way it already reads its theme colors — keeping the graph in step with light/dark mode and the brand. The names above are the contract.

## Files

- `src/tokens/colors.css` — viz vars in all four theme blocks (light `@theme`, dark `@media @theme`, `[data-theme='dark'|'light']`).
- `src/tokens/index.ts` — `dataViz` / `dataVizDark` + aggregate `tokens` wiring.
- `src/__tests__/tokens.test.ts` — palette shape, unique-hue, aggregate assertions.
- `docs/brand/color-palette.md` — new Categorical/Data-Viz section + per-token contrast tables.

## ⚠️ Serial-merge note (re: ds#104 — @cc Maricel)

This PR adds vars **inside** the `colors.css` `@theme` blocks. The published `dist/styles.css` currently emits the default-mode block as **literal `@theme{…}`** (which browsers ignore) — i.e. the default-`:root` custom properties don't resolve from the published CSS today. This affects **all** `@theme` tokens, not just mine, and is exactly what **ds#104** fixes. My light-default viz vars live in that same block, so they inherit the ds#104 fix automatically; the `[data-theme]` toggle paths already emit real selectors and work today.

If ds#104 restructures the `@theme` blocks in `colors.css` (e.g. `@theme`→`:root`), expect a **merge conflict on `colors.css`** — my 11 new vars must be carried into the new structure. Recommend sequencing ds#104 first, then I rebase; or merge this first and let ds#104's restructure absorb the new vars. Flagging so you can order the merges. `dist/` is gitignored — not committed here.

## Test Plan

`npm run check` (in worktree, fresh `npm install`):
- **lint** — 0 errors (3 pre-existing `react-refresh` warnings in badge/button/toast, untouched here)
- **typecheck** — clean
- **test** — 74 passed (tokens.test.ts now 17, +2 new)
- `npm run build` — succeeds; viz vars present in `dist/styles.css` (all 4 blocks) and `dataViz` typed in `dist/tokens/index.d.ts`.

Reviewers: @Astrid Lindqvist (primary), @Keanu Tama (secondary).
