### PR TITLE
feat(icons): framework-neutral iconPaths export (#103)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,13 @@
     },
     "./icons": {
       "types": "./dist/icons/index.d.ts",
-      "import": "./dist/icons/index.js"
+      "import": "./dist/icons/index.js",
+      "require": "./dist/icons/index.cjs"
+    },
+    "./icons/paths": {
+      "types": "./dist/icons/paths.d.ts",
+      "import": "./dist/icons/paths.js",
+      "require": "./dist/icons/paths.cjs"
     },
     "./styles": "./dist/styles.css",
     "./styles.css": "./dist/styles.css"

--- a/src/__tests__/icon-paths.test.ts
+++ b/src/__tests__/icon-paths.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { ICON_NAMES, iconBaseAttributes, iconPaths, renderIconSvg } from '../icons/paths'
+
+describe('iconPaths (framework-neutral geometry)', () => {
+  it('has inner markup for every declared icon name', () => {
+    for (const name of ICON_NAMES) {
+      expect(iconPaths[name], `missing markup for ${name}`).toBeTruthy()
+    }
+  })
+
+  it('exposes exactly the functional icon set', () => {
+    expect([...ICON_NAMES].sort()).toEqual(
+      [
+        'admin',
+        'collections',
+        'compare',
+        'graph-explorer',
+        'hadiths',
+        'narrators',
+        'search',
+        'sign-out',
+        'timeline',
+      ].sort(),
+    )
+  })
+
+  it('uses SVG-native (kebab-case) attribute names so it renders verbatim in any DOM', () => {
+    for (const markup of Object.values(iconPaths)) {
+      // No React-style camelCase attributes should leak into the neutral markup.
+      expect(markup).not.toMatch(/strokeWidth|strokeDasharray|strokeLinecap/)
+    }
+    // Spot-check that the kebab-case forms are present where expected.
+    expect(iconPaths['graph-explorer']).toContain('stroke-dasharray="2 2"')
+    expect(iconPaths.hadiths).toContain('stroke-width="1"')
+  })
+
+  it('shares the canonical 24x24 stroke base attributes', () => {
+    expect(iconBaseAttributes.viewBox).toBe('0 0 24 24')
+    expect(iconBaseAttributes.stroke).toBe('currentColor')
+    expect(iconBaseAttributes['stroke-width']).toBe('1.5')
+  })
+})
+
+describe('renderIconSvg', () => {
+  it('wraps the geometry in a complete <svg> with the shared base attributes', () => {
+    const svg = renderIconSvg('search')
+    expect(svg.startsWith('<svg ')).toBe(true)
+    expect(svg.endsWith('</svg>')).toBe(true)
+    expect(svg).toContain('viewBox="0 0 24 24"')
+    expect(svg).toContain('stroke="currentColor"')
+    expect(svg).toContain('width="16"')
+    expect(svg).toContain('height="16"')
+    expect(svg).toContain(iconPaths.search)
+  })
+
+  it('honours a custom size', () => {
+    const svg = renderIconSvg('narrators', { size: 32 })
+    expect(svg).toContain('width="32"')
+    expect(svg).toContain('height="32"')
+  })
+
+  it('merges and overrides extra attributes (e.g. class, aria)', () => {
+    const svg = renderIconSvg('admin', {
+      attributes: { class: 'qalam-icon', 'aria-hidden': 'false', 'aria-label': 'Admin' },
+    })
+    expect(svg).toContain('class="qalam-icon"')
+    expect(svg).toContain('aria-hidden="false"')
+    expect(svg).toContain('aria-label="Admin"')
+  })
+})

--- a/src/icons/admin-icon.tsx
+++ b/src/icons/admin-icon.tsx
@@ -3,15 +3,5 @@ import { IconBase } from './icon-base'
 
 /** Admin — gear with octagonal geometric accent */
 export function AdminIcon(props: IconProps) {
-  return (
-    <IconBase {...props}>
-      {/* Gear outer — octagonal shape for Islamic geometric feel */}
-      <path
-        d="M12 2l2.2 1.3 2.5-.3 1.3 2.2 2.5.3.3 2.5 2.2 1.3L22 12l1.3 2.2-.3 2.5-2.2 1.3-.3 2.5-2.5.3-1.3 2.2-2.5-.3L12 22l-2.2-1.3-2.5.3-1.3-2.2-2.5-.3-.3-2.5L1 14.7 2 12 .7 9.3l.3-2.5 2.2-1.3.3-2.5 2.5-.3L7.3 2.7l2.5.3z"
-        strokeWidth="1.2"
-      />
-      {/* Inner circle */}
-      <circle cx="12" cy="12" r="3" />
-    </IconBase>
-  )
+  return <IconBase {...props} icon="admin" />
 }

--- a/src/icons/collections-icon.tsx
+++ b/src/icons/collections-icon.tsx
@@ -3,23 +3,5 @@ import { IconBase } from './icon-base'
 
 /** Collections — library/bookshelf with geometric shelf brackets */
 export function CollectionsIcon(props: IconProps) {
-  return (
-    <IconBase {...props}>
-      {/* Shelf */}
-      <path d="M3 21h18" />
-      <path d="M3 13h18" />
-      {/* Books on top shelf */}
-      <rect x="5" y="5" width="3" height="8" rx="0.5" />
-      <rect x="9" y="3" width="2.5" height="10" rx="0.5" />
-      <rect x="12.5" y="6" width="3" height="7" rx="0.5" />
-      <rect x="16.5" y="4" width="2.5" height="9" rx="0.5" />
-      {/* Books on bottom shelf */}
-      <rect x="5" y="14" width="4" height="7" rx="0.5" />
-      <rect x="10" y="15" width="3" height="6" rx="0.5" />
-      <rect x="14" y="14" width="3" height="7" rx="0.5" />
-      {/* Geometric bracket accents */}
-      <path d="M3 13l1-1 1 1" strokeWidth="1" opacity="0.5" />
-      <path d="M19 13l1-1 1 1" strokeWidth="1" opacity="0.5" />
-    </IconBase>
-  )
+  return <IconBase {...props} icon="collections" />
 }

--- a/src/icons/compare-icon.tsx
+++ b/src/icons/compare-icon.tsx
@@ -3,19 +3,5 @@ import { IconBase } from './icon-base'
 
 /** Compare — split/diff with geometric separator */
 export function CompareIcon(props: IconProps) {
-  return (
-    <IconBase {...props}>
-      {/* Left panel */}
-      <rect x="2" y="3" width="8" height="18" rx="1" />
-      {/* Right panel */}
-      <rect x="14" y="3" width="8" height="18" rx="1" />
-      {/* Connecting arrows */}
-      <path d="M10 8h4" />
-      <path d="M14 8l-1.5-1.5M14 8l-1.5 1.5" />
-      <path d="M14 16h-4" />
-      <path d="M10 16l1.5-1.5M10 16l1.5 1.5" />
-      {/* Diamond separator accent */}
-      <path d="M12 11l1 1-1 1-1-1z" fill="currentColor" stroke="none" opacity="0.5" />
-    </IconBase>
-  )
+  return <IconBase {...props} icon="compare" />
 }

--- a/src/icons/graph-explorer-icon.tsx
+++ b/src/icons/graph-explorer-icon.tsx
@@ -3,22 +3,5 @@ import { IconBase } from './icon-base'
 
 /** Graph Explorer — network constellation with nodes and edges */
 export function GraphExplorerIcon(props: IconProps) {
-  return (
-    <IconBase {...props}>
-      {/* Central node */}
-      <circle cx="12" cy="12" r="2.5" />
-      {/* Outer nodes */}
-      <circle cx="5" cy="6" r="1.5" />
-      <circle cx="19" cy="6" r="1.5" />
-      <circle cx="5" cy="18" r="1.5" />
-      <circle cx="19" cy="18" r="1.5" />
-      {/* Edges connecting to center */}
-      <path d="M6.3 7.2L9.7 10.2" />
-      <path d="M17.7 7.2L14.3 10.2" />
-      <path d="M6.3 16.8L9.7 13.8" />
-      <path d="M17.7 16.8L14.3 13.8" />
-      {/* Cross-edges for network feel */}
-      <path d="M6.5 6h11" strokeDasharray="2 2" strokeWidth="1" opacity="0.3" />
-    </IconBase>
-  )
+  return <IconBase {...props} icon="graph-explorer" />
 }

--- a/src/icons/hadiths-icon.tsx
+++ b/src/icons/hadiths-icon.tsx
@@ -3,16 +3,5 @@ import { IconBase } from './icon-base'
 
 /** Hadiths — open manuscript/scroll */
 export function HadithsIcon(props: IconProps) {
-  return (
-    <IconBase {...props}>
-      {/* Open book body */}
-      <path d="M2 4s2-1 5-1 5 1 5 1v16s-2-1-5-1-5 1-5 1z" />
-      <path d="M12 4s2-1 5-1 5 1 5 1v16s-2-1-5-1-5 1-5 1z" />
-      {/* Spine */}
-      <path d="M12 4v16" />
-      {/* Text lines on left page */}
-      <path d="M5 8h3" strokeWidth="1" opacity="0.5" />
-      <path d="M5 11h3" strokeWidth="1" opacity="0.5" />
-    </IconBase>
-  )
+  return <IconBase {...props} icon="hadiths" />
 }

--- a/src/icons/icon-base.tsx
+++ b/src/icons/icon-base.tsx
@@ -1,14 +1,47 @@
 import type { IconProps } from './types'
+import { iconPaths, type IconName } from './paths'
+
+interface IconBaseProps extends IconProps {
+  /**
+   * Render geometry from the shared framework-neutral {@link iconPaths} map (#103),
+   * the single source of truth for the Qalam functional icon set. When omitted, the
+   * caller supplies its own `children` (custom / utility icons).
+   *
+   * Named `icon` rather than `name` to avoid colliding with the SVG `name` attribute
+   * carried by `SVGAttributes`.
+   */
+  icon?: IconName
+  children?: React.ReactNode
+}
 
 /**
  * Base wrapper for 24x24 stroke-based Qalam icons.
  * All icons use currentColor, work in light/dark mode, and are inline-friendly.
+ *
+ * Pass `icon` to render a functional icon from the shared `iconPaths` geometry, or
+ * pass `children` to draw a custom/utility icon inline.
  */
-export function IconBase({
-  size = 16,
-  children,
-  ...props
-}: IconProps & { children: React.ReactNode }) {
+export function IconBase({ size = 16, icon, children, ...props }: IconBaseProps) {
+  if (icon) {
+    // Geometry comes from the framework-neutral source of truth so the React and
+    // non-React renderings can never drift.
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        dangerouslySetInnerHTML={{ __html: iconPaths[icon] }}
+        {...props}
+      />
+    )
+  }
+
   return (
     <svg
       width={size}

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,6 +1,12 @@
 // Types
 export type { IconProps, IllustrationProps } from './types'
 
+// Framework-neutral icon geometry — single source of truth for the functional
+// icon set (#103). Also published standalone at `@noorinalabs/design-system/icons/paths`
+// for non-React (Astro / plain-DOM) consumers.
+export { ICON_NAMES, iconBaseAttributes, iconPaths, renderIconSvg } from './paths'
+export type { IconName, RenderIconOptions } from './paths'
+
 // Base components (for custom icon creation)
 export { IconBase } from './icon-base'
 export { IllustrationBase } from './illustration-base'

--- a/src/icons/narrators-icon.tsx
+++ b/src/icons/narrators-icon.tsx
@@ -3,14 +3,5 @@ import { IconBase } from './icon-base'
 
 /** Narrators — scholar/person with turban silhouette accent */
 export function NarratorsIcon(props: IconProps) {
-  return (
-    <IconBase {...props}>
-      {/* Head */}
-      <circle cx="12" cy="7" r="4" />
-      {/* Shoulders */}
-      <path d="M5 21v-2a7 7 0 0 1 14 0v2" />
-      {/* Small diamond accent at collar — Islamic geometric motif */}
-      <path d="M12 15l1.2 1.2L12 17.4l-1.2-1.2z" fill="currentColor" stroke="none" />
-    </IconBase>
-  )
+  return <IconBase {...props} icon="narrators" />
 }

--- a/src/icons/paths.ts
+++ b/src/icons/paths.ts
@@ -1,0 +1,154 @@
+/**
+ * Framework-neutral icon geometry — the single source of truth for the Qalam
+ * functional icon set (#103).
+ *
+ * The React icon components (`./icon-base`, `./*-icon`) render *from* this module,
+ * and non-React consumers (the Astro landing page, any plain-DOM consumer) can build
+ * an `<svg>` from the same data — so the two can never drift. Attribute names here are
+ * SVG-native (kebab-case) so every string renders verbatim in any DOM/markup context.
+ *
+ * Consume via the stable subpath: `@noorinalabs/design-system/icons/paths`.
+ */
+
+/** Canonical functional icon names. */
+export const ICON_NAMES = [
+  'graph-explorer',
+  'narrators',
+  'hadiths',
+  'collections',
+  'search',
+  'compare',
+  'timeline',
+  'admin',
+  'sign-out',
+] as const
+
+export type IconName = (typeof ICON_NAMES)[number]
+
+/**
+ * Shared root `<svg>` attributes for every Qalam icon. Names are SVG-native so the
+ * map is directly usable by string/DOM consumers; React's `IconBase` applies the
+ * camelCase equivalents on its JSX wrapper.
+ */
+export const iconBaseAttributes = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  'stroke-width': '1.5',
+  'stroke-linecap': 'round',
+  'stroke-linejoin': 'round',
+} as const
+
+/**
+ * Inner SVG markup for each icon — the children that sit inside the shared `<svg>`
+ * wrapper described by {@link iconBaseAttributes}. This is the geometry the React
+ * components and every non-React consumer share.
+ */
+export const iconPaths: Record<IconName, string> = {
+  'graph-explorer': [
+    '<circle cx="12" cy="12" r="2.5" />',
+    '<circle cx="5" cy="6" r="1.5" />',
+    '<circle cx="19" cy="6" r="1.5" />',
+    '<circle cx="5" cy="18" r="1.5" />',
+    '<circle cx="19" cy="18" r="1.5" />',
+    '<path d="M6.3 7.2L9.7 10.2" />',
+    '<path d="M17.7 7.2L14.3 10.2" />',
+    '<path d="M6.3 16.8L9.7 13.8" />',
+    '<path d="M17.7 16.8L14.3 13.8" />',
+    '<path d="M6.5 6h11" stroke-dasharray="2 2" stroke-width="1" opacity="0.3" />',
+  ].join(''),
+  narrators: [
+    '<circle cx="12" cy="7" r="4" />',
+    '<path d="M5 21v-2a7 7 0 0 1 14 0v2" />',
+    '<path d="M12 15l1.2 1.2L12 17.4l-1.2-1.2z" fill="currentColor" stroke="none" />',
+  ].join(''),
+  hadiths: [
+    '<path d="M2 4s2-1 5-1 5 1 5 1v16s-2-1-5-1-5 1-5 1z" />',
+    '<path d="M12 4s2-1 5-1 5 1 5 1v16s-2-1-5-1-5 1-5 1z" />',
+    '<path d="M12 4v16" />',
+    '<path d="M5 8h3" stroke-width="1" opacity="0.5" />',
+    '<path d="M5 11h3" stroke-width="1" opacity="0.5" />',
+  ].join(''),
+  collections: [
+    '<path d="M3 21h18" />',
+    '<path d="M3 13h18" />',
+    '<rect x="5" y="5" width="3" height="8" rx="0.5" />',
+    '<rect x="9" y="3" width="2.5" height="10" rx="0.5" />',
+    '<rect x="12.5" y="6" width="3" height="7" rx="0.5" />',
+    '<rect x="16.5" y="4" width="2.5" height="9" rx="0.5" />',
+    '<rect x="5" y="14" width="4" height="7" rx="0.5" />',
+    '<rect x="10" y="15" width="3" height="6" rx="0.5" />',
+    '<rect x="14" y="14" width="3" height="7" rx="0.5" />',
+    '<path d="M3 13l1-1 1 1" stroke-width="1" opacity="0.5" />',
+    '<path d="M19 13l1-1 1 1" stroke-width="1" opacity="0.5" />',
+  ].join(''),
+  search: [
+    '<circle cx="11" cy="11" r="7" />',
+    '<path d="M21 21l-4.35-4.35" />',
+    '<path d="M11 7l1 2.5L14.5 11l-2.5 1L11 14.5l-1-2.5L7.5 11l2.5-1z" fill="currentColor" stroke="none" opacity="0.35" />',
+  ].join(''),
+  compare: [
+    '<rect x="2" y="3" width="8" height="18" rx="1" />',
+    '<rect x="14" y="3" width="8" height="18" rx="1" />',
+    '<path d="M10 8h4" />',
+    '<path d="M14 8l-1.5-1.5M14 8l-1.5 1.5" />',
+    '<path d="M14 16h-4" />',
+    '<path d="M10 16l1.5-1.5M10 16l1.5 1.5" />',
+    '<path d="M12 11l1 1-1 1-1-1z" fill="currentColor" stroke="none" opacity="0.5" />',
+  ].join(''),
+  timeline: [
+    '<path d="M3 12h18" />',
+    '<circle cx="6" cy="12" r="1.5" fill="currentColor" stroke="none" />',
+    '<circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none" />',
+    '<circle cx="18" cy="12" r="1.5" fill="currentColor" stroke="none" />',
+    '<path d="M10.5 7a2.5 2.5 0 0 1 3 0" />',
+    '<path d="M11 7.2a1.8 1.8 0 0 0 2 0" />',
+    '<path d="M6 9v-2" stroke-width="1" opacity="0.4" />',
+    '<path d="M18 9v-2" stroke-width="1" opacity="0.4" />',
+  ].join(''),
+  admin: [
+    '<path d="M12 2l2.2 1.3 2.5-.3 1.3 2.2 2.5.3.3 2.5 2.2 1.3L22 12l1.3 2.2-.3 2.5-2.2 1.3-.3 2.5-2.5.3-1.3 2.2-2.5-.3L12 22l-2.2-1.3-2.5.3-1.3-2.2-2.5-.3-.3-2.5L1 14.7 2 12 .7 9.3l.3-2.5 2.2-1.3.3-2.5 2.5-.3L7.3 2.7l2.5.3z" stroke-width="1.2" />',
+    '<circle cx="12" cy="12" r="3" />',
+  ].join(''),
+  'sign-out': [
+    '<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />',
+    '<polyline points="16 17 21 12 16 7" />',
+    '<line x1="21" y1="12" x2="9" y2="12" />',
+  ].join(''),
+}
+
+/** Options for {@link renderIconSvg}. */
+export interface RenderIconOptions {
+  /** Width and height in px (number) or any CSS length (string). Defaults to 16. */
+  size?: number | string
+  /**
+   * Extra attributes merged onto the root `<svg>` (e.g. `class`, `aria-label`,
+   * `role`). Override `aria-hidden` here when the icon is meaningful on its own.
+   */
+  attributes?: Record<string, string | number>
+}
+
+const escapeAttr = (value: string | number): string =>
+  String(value).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
+
+/**
+ * Serialize a Qalam icon to a complete `<svg>…</svg>` string for non-React
+ * consumers (Astro `set:html`, plain DOM `innerHTML`, server-rendered markup).
+ *
+ * @example
+ *   element.innerHTML = renderIconSvg('search', { size: 20 })
+ */
+export function renderIconSvg(name: IconName, options: RenderIconOptions = {}): string {
+  const { size = 16, attributes = {} } = options
+  const attrs: Record<string, string | number> = {
+    ...iconBaseAttributes,
+    width: size,
+    height: size,
+    'aria-hidden': 'true',
+    ...attributes,
+  }
+  const attrString = Object.entries(attrs)
+    .map(([key, value]) => `${key}="${escapeAttr(value)}"`)
+    .join(' ')
+  return `<svg ${attrString}>${iconPaths[name]}</svg>`
+}

--- a/src/icons/search-icon.tsx
+++ b/src/icons/search-icon.tsx
@@ -3,19 +3,5 @@ import { IconBase } from './icon-base'
 
 /** Search — magnifying glass with 4-fold star in lens */
 export function SearchIcon(props: IconProps) {
-  return (
-    <IconBase {...props}>
-      {/* Lens */}
-      <circle cx="11" cy="11" r="7" />
-      {/* Handle */}
-      <path d="M21 21l-4.35-4.35" />
-      {/* 4-pointed star motif inside lens */}
-      <path
-        d="M11 7l1 2.5L14.5 11l-2.5 1L11 14.5l-1-2.5L7.5 11l2.5-1z"
-        fill="currentColor"
-        stroke="none"
-        opacity="0.35"
-      />
-    </IconBase>
-  )
+  return <IconBase {...props} icon="search" />
 }

--- a/src/icons/sign-out-icon.tsx
+++ b/src/icons/sign-out-icon.tsx
@@ -3,11 +3,5 @@ import { IconBase } from './icon-base'
 
 /** Sign out — door with arrow */
 export function SignOutIcon(props: IconProps) {
-  return (
-    <IconBase {...props}>
-      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-      <polyline points="16 17 21 12 16 7" />
-      <line x1="21" y1="12" x2="9" y2="12" />
-    </IconBase>
-  )
+  return <IconBase {...props} icon="sign-out" />
 }

--- a/src/icons/timeline-icon.tsx
+++ b/src/icons/timeline-icon.tsx
@@ -3,20 +3,5 @@ import { IconBase } from './icon-base'
 
 /** Timeline — horizontal timeline with crescent markers */
 export function TimelineIcon(props: IconProps) {
-  return (
-    <IconBase {...props}>
-      {/* Horizontal line */}
-      <path d="M3 12h18" />
-      {/* Timeline nodes */}
-      <circle cx="6" cy="12" r="1.5" fill="currentColor" stroke="none" />
-      <circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none" />
-      <circle cx="18" cy="12" r="1.5" fill="currentColor" stroke="none" />
-      {/* Crescent accent above center node */}
-      <path d="M10.5 7a2.5 2.5 0 0 1 3 0" />
-      <path d="M11 7.2a1.8 1.8 0 0 0 2 0" />
-      {/* Tick marks */}
-      <path d="M6 9v-2" strokeWidth="1" opacity="0.4" />
-      <path d="M18 9v-2" strokeWidth="1" opacity="0.4" />
-    </IconBase>
-  )
+  return <IconBase {...props} icon="timeline" />
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,9 +15,16 @@ export default defineConfig({
   ],
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
+      // Multi-entry so subpath imports resolve to real emitted files. Previously a
+      // single `index` entry meant `./icons` pointed at a file that was never built
+      // (only its .d.ts existed); `./icons/paths` (#103) needs the same treatment.
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        'icons/index': resolve(__dirname, 'src/icons/index.ts'),
+        'icons/paths': resolve(__dirname, 'src/icons/paths.ts'),
+      },
       formats: ['es', 'cjs'],
-      fileName: 'index',
+      fileName: (format, entryName) => `${entryName}.${format === 'es' ? 'js' : 'cjs'}`,
     },
     sourcemap: true,
     cssCodeSplit: false,


### PR DESCRIPTION
Closes #103.

## What

Adds a **framework-neutral icon-geometry export** so non-React consumers (the Astro landing page, any plain-DOM consumer) can render the Qalam functional icon set without React — and makes the existing React components render *from* the same data so the two can never drift.

### New source of truth — `src/icons/paths.ts`
- `iconPaths: Record<IconName, string>` — inner SVG markup for each of the 9 functional icons (`graph-explorer`, `narrators`, `hadiths`, `collections`, `search`, `compare`, `timeline`, `admin`, `sign-out`). Attribute names are **SVG-native (kebab-case)** so each string renders verbatim in any DOM/markup context.
- `iconBaseAttributes` — the shared root `<svg>` attrs (`viewBox 0 0 24 24`, `stroke currentColor`, `stroke-width 1.5`, round caps/joins).
- `ICON_NAMES` / `IconName` — the canonical name set + type.
- `renderIconSvg(name, { size, attributes })` — serializes a complete `<svg>…</svg>` string for non-React consumers.

### React refactor
- `IconBase` gains an `icon` prop; when set, it renders the geometry from `iconPaths` (named `icon` not `name` to avoid colliding with the SVG `name` attribute on `SVGAttributes`). `children` support is retained for the utility/custom icons and illustrations, so nothing else changes.
- The 9 functional icon components are now thin wrappers: `<IconBase {...props} icon="search" />`. Geometry lives **only** in `paths.ts` — extracted from the existing components, not retyped, so rendering is byte-faithful.

## New subpath

```ts
// non-React (Astro / plain DOM)
import { renderIconSvg } from '@noorinalabs/design-system/icons/paths'
el.innerHTML = renderIconSvg('graph-explorer', { size: 20 })

// or build your own <svg> from the parts
import { iconPaths, iconBaseAttributes } from '@noorinalabs/design-system/icons/paths'
```

`iconPaths` & friends are also re-exported from `@noorinalabs/design-system/icons` and the package root.

## package.json `exports` touched
- **Added** `"./icons/paths"` → `{ types: dist/icons/paths.d.ts, import: dist/icons/paths.js, require: dist/icons/paths.cjs }`.
- **Added** a `require` (CJS) condition to the existing `"./icons"` entry (it now emits `.cjs` too).

## Build change (note for #102/#104)
Switched the vite lib build to **multi-entry** (`index`, `icons/index`, `icons/paths`) so the subpath files are actually emitted to `dist/`. This also **fixes the pre-existing broken `./icons` subpath** flagged in the issue's side-finding — it pointed at a `dist/icons/index.js` that was never built (only its `.d.ts` existed). `vite.config.ts` and `package.json` are the only shared/config files touched — #102/#104 (color tokens) may also touch `package.json`, but only the `exports` block here.

## Verification
- `npm run check` — green (lint 0 errors, typecheck clean, **79 tests** incl. 7 new in `icon-paths.test.ts`).
- `npm run build` — emits `dist/icons/paths.{js,cjs,d.ts}` and `dist/icons/index.{js,cjs,d.ts}`; verified every `exports` target resolves to a real file and `require('./dist/icons/paths.cjs').renderIconSvg('search', {size:20})` produces correct SVG.

## Test Plan
- [x] `npm run check` green
- [x] `npm run build` emits all subpath artifacts; exports map targets all exist
- [x] Runtime sanity: built CJS `renderIconSvg` / `iconPaths` import + render
- [ ] Post-merge: lp#119 swaps its interim `Icon.astro` geometry for `iconPaths` (byte-identical check there)

## Unblocks
landing-page#121 / lp#119 (interim DS-geometry mirror), isnad-graph DS-icon adoption (ig#978).

Reviewers: @Maricel Reyes (primary), @Keanu Tama (secondary).
