### PR TITLE
fix(build): compile @theme tokens to plain :root CSS vars in dist (#104)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,19 @@ jobs:
           grep 'dist/index.cjs' /tmp/pack-output.txt || (echo "FAIL: dist/index.cjs missing from package" && exit 1)
           echo "Package contents verified"
 
+      - name: Verify base tokens compiled to :root (not raw @theme) — #104
+        run: |
+          # The published dist is consumed as plain CSS. A raw Tailwind `@theme {}`
+          # block is an unknown at-rule to browsers and is silently ignored, so any
+          # base token trapped inside it never applies for non-Tailwind consumers.
+          if grep -q '@theme' dist/styles.css; then
+            echo "FAIL: raw @theme leaked into published dist/styles.css — base tokens will be ignored by non-Tailwind consumers (#104)"
+            exit 1
+          fi
+          grep -q -- '--color-border:' dist/styles.css || (echo "FAIL: --color-border not emitted to dist (#104)" && exit 1)
+          grep -q ':root' dist/styles.css || (echo "FAIL: no :root selector in dist (#104)" && exit 1)
+          echo "Base tokens compiled to :root — verified (#104)"
+
       - name: Verify exports field resolution
         run: node scripts/validate-package-exports.mjs
 

--- a/src/__tests__/dist-tokens.test.ts
+++ b/src/__tests__/dist-tokens.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/*
+ * Published-dist token-resolution guard (#104).
+ *
+ * The bug: base tokens were authored in Tailwind v4 `@theme {}` blocks. `@theme`
+ * is a build-time directive — when the dist is consumed as plain CSS (any
+ * non-Tailwind consumer, or a browser directly), `@theme {}` is an unknown
+ * at-rule and is silently ignored, so every `var(--color-*)` resolved to empty.
+ *
+ * These assertions run against the *built* dist (CI runs `npm run build` before
+ * `npm run test`), so they verify the published artifact actually emits the
+ * tokens to a browser-honored `:root` selector — i.e. they test *resolution*,
+ * not mere token *existence*, which is what the original review/CI missed.
+ *
+ * When the dist has not been built (e.g. a bare `npm run test` with no prior
+ * build), the suite skips rather than failing — CI is the enforcement point.
+ */
+const distCssPath = resolve(process.cwd(), 'dist/styles.css')
+const distBuilt = existsSync(distCssPath)
+
+describe.skipIf(!distBuilt)('published dist token resolution (#104)', () => {
+  const css = distBuilt ? readFileSync(distCssPath, 'utf8') : ''
+
+  it('ships no raw Tailwind @theme block (browsers ignore it)', () => {
+    expect(css).not.toContain('@theme')
+  })
+
+  it('emits base surface/semantic tokens to a :root selector', () => {
+    // Grab every :root{...} body (light base + prefers-dark + others) and
+    // assert the critical base tokens are declared in at least one of them.
+    const rootBodies = [...css.matchAll(/:root\s*\{([^}]*)\}/g)].map((m) => m[1])
+    const allRoot = rootBodies.join('\n')
+    for (const token of [
+      '--color-background',
+      '--color-foreground',
+      '--color-border',
+      '--color-primary',
+      '--color-card',
+      '--spacing-3',
+    ]) {
+      expect(allRoot, `${token} must resolve in :root, not @theme`).toContain(`${token}:`)
+    }
+  })
+
+  it('keeps the explicit [data-theme] override blocks for opt-in theming', () => {
+    expect(css).toContain('[data-theme=dark]')
+    expect(css).toContain('[data-theme=light]')
+  })
+})

--- a/src/tokens/colors.css
+++ b/src/tokens/colors.css
@@ -16,7 +16,16 @@
 /* ============================================================
  * LIGHT MODE (default)
  * ============================================================ */
-@theme {
+/*
+ * Base tokens are declared in :root (plain CSS custom properties), NOT a
+ * Tailwind `@theme {}` block. `@theme` is a build-time directive; this library
+ * ships its tokens as plain CSS (no `@import "tailwindcss"` in the dist build
+ * graph), so a raw `@theme` block survives uncompiled into the published
+ * dist/styles.css, where browsers treat it as an unknown at-rule and ignore it —
+ * silently dropping every base token for non-Tailwind consumers. Emitting to
+ * :root makes the default (light) theme apply for ANY CSS consumer. See #104.
+ */
+:root {
   /* --- Semantic colors --- */
   --color-primary: oklch(0.55 0.14 45);
   --color-primary-hover: oklch(0.6 0.14 45);
@@ -90,7 +99,7 @@
  * DARK MODE — prefers-color-scheme
  * ============================================================ */
 @media (prefers-color-scheme: dark) {
-  @theme {
+  :root {
     /* Surface colors */
     --color-background: oklch(0.2 0.015 260);
     --color-foreground: oklch(0.92 0.01 85);

--- a/src/tokens/container.css
+++ b/src/tokens/container.css
@@ -1,15 +1,19 @@
 /*
  * Container Tokens — Qalam Design System
  * ========================================
- * Tailwind 4's `--container-*` theme namespace drives `max-w-*` / `min-w-*`
- * utilities. Mirrors Tailwind's stock scale so consumers importing
- * @noorinalabs/design-system/styles.css resolve `max-w-md` etc. correctly.
+ * Mirrors Tailwind's stock `--container-*` scale so the `--container-md` etc.
+ * custom properties are available to consumers of the published plain-CSS dist.
  *
- * Without this namespace, `max-w-md` falls through to `--spacing-md` (1rem),
- * producing 16px-wide containers — see issue #82 (latent #889-class bugs).
+ * Declared in :root (not a Tailwind `@theme {}` block) so the values compile
+ * into dist/styles.css and are honored by all consumers, including non-Tailwind
+ * ones. `@theme` is a build-time directive that a plain-CSS consumer's browser
+ * ignores (see #104). A Tailwind-pipeline consumer that needs `max-w-*`
+ * utilities backed by this scale should register `--container-*` in its own
+ * `@theme` namespace (this dist ships compiled CSS, not Tailwind source).
+ * Background on the stock scale: issue #82 (latent #889-class bugs).
  */
 
-@theme {
+:root {
   --container-3xs: 16rem;
   --container-2xs: 18rem;
   --container-xs: 20rem;

--- a/src/tokens/spacing.css
+++ b/src/tokens/spacing.css
@@ -7,7 +7,9 @@
  * Borders: width scale
  */
 
-@theme {
+/* Declared in :root, not Tailwind `@theme`, so these compile into the plain-CSS
+ * dist and are honored by all consumers (not just Tailwind pipelines). See #104. */
+:root {
   /* --- Border radii --- */
   --radius-sm: 0.25rem;
   --radius-md: 0.375rem;


### PR DESCRIPTION
## Summary
Fixes #104 — the published `dist/styles.css` shipped base tokens inside raw Tailwind v4 `@theme {}` blocks. `@theme` is a build-time directive; browsers treat it as an unknown at-rule and ignore it. Because this library ships its tokens as **plain CSS** (the only `@import "tailwindcss"` lives in an orphaned `globals.css` that nothing in the `index.ts` build graph imports), the `@theme` blocks survived **uncompiled** into the dist — so every `var(--color-*)` / `var(--spacing-*)` resolved to empty for non-Tailwind consumers unless they explicitly set `data-theme` on `<html>`.

Fix (issue's **option A — durable**): declare the base tokens in `:root` (as `typography.css` and `shadows.css` already did). The default light theme — and the `prefers-color-scheme` dark `@media :root` overrides — now apply for **any** CSS consumer. The explicit `[data-theme=light|dark]` opt-in blocks are unchanged.

## Before / after (grep of built `dist/styles.css` for `@theme`)
```
# before
$ grep -c '@theme' dist/styles.css
1                 # raw @theme{...} block at line 1 — ignored by browsers
$ grep -o -- '--color-border' <(grep ':root' dist/styles.css)
                  # (empty — base tokens were NOT in :root)

# after
$ grep -c '@theme' dist/styles.css
0
$ grep -oE -- '--color-border: oklch\([^)]*\)' dist/styles.css
--color-border: oklch(.85 .01 85)
$ grep -oE '@media[^{]*\{:root' dist/styles.css | grep prefers
@media(prefers-color-scheme:dark){:root   # auto dark mode now works for plain-CSS consumers too
```

## Changes
- `src/tokens/colors.css` — light base `@theme` → `:root`; prefers-dark `@media @theme` → `@media :root`.
- `src/tokens/spacing.css` — `@theme` → `:root`. These are consumed by the DS's own hand-written component CSS via `var()`, so they were **latently broken** in plain-CSS consumers too.
- `src/tokens/container.css` — `@theme` → `:root`; values unchanged, still available as `--container-*` custom properties. (See "Trade-off" below.)
- `src/__tests__/dist-tokens.test.ts` — regression guard asserting the **built dist** emits base tokens to `:root` and contains no raw `@theme`. Tests **resolution**, not mere token existence — the exact gap the original review/CI missed. Skips if the dist isn't built (CI runs `build` before `test`, so it executes there).
- `.github/workflows/ci.yml` — artifact-level grep gate in `validate-package`: fails if the published dist contains raw `@theme` or is missing base tokens.

## Trade-off surfaced (container tokens)
`--container-*` was a Tailwind `@theme` namespace whose only purpose is generating `max-w-*`/`min-w-*` utilities (per #82). The **published dist never generated those utilities** anyway (no `tailwindcss` import in the build graph), so converting to `:root` regresses no working behavior — the values stay available as `var(--container-*)`. A Tailwind-pipeline consumer that wants utilities backed by this scale should register `--container-*` in its own `@theme` (this dist ships compiled CSS, not Tailwind source). Comment updated accordingly. Flagging for reviewer judgement.

## Test Plan
- `npm run build` → `dist/styles.css`: `grep -c '@theme'` = **0**; `--color-border`, `--spacing-3`, `--container-md` all present in `:root`.
- `npm run check` (lint + typecheck + test): green. 75/75 tests pass incl. 3 new dist guards. (Lint: 0 errors; 3 pre-existing react-refresh warnings, untouched.)
- `[data-theme=dark]` / `[data-theme=light]` override blocks confirmed intact in dist.

## Reviewers
@Keanu Tama (DS architect, primary) · @Nhan Pham (accessibility, secondary)

Closes #104
