### PR TITLE
fix(release): bump version + publish drift-guard so #107's :root dist actually ships (#111)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,10 +43,44 @@ jobs:
           echo "version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
           if npm view "@noorinalabs/design-system@$PKG_VERSION" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
             echo "already_published=true" >> "$GITHUB_OUTPUT"
-            echo "Version $PKG_VERSION already published — skipping publish step."
+            echo "Version $PKG_VERSION already on registry — publish step will be skipped (drift guard runs first)."
           else
             echo "already_published=false" >> "$GITHUB_OUTPUT"
             echo "Version $PKG_VERSION not yet on registry — will publish."
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Silent-drop guard (#111): when the version already exists the Publish
+      # step below is skipped, so a dist-only change made WITHOUT a version bump
+      # would never reach consumers — with green CI. (This is exactly how #107's
+      # `:root` token fix was lost: dist changed, version stayed 0.0.5-wave4.0,
+      # publish no-op'd.) Diff the freshly-built dist/ against the dist/ inside
+      # the already-published tarball; if they differ, fail and demand a bump.
+      - name: Guard — dist drift at unchanged version (#111)
+        if: steps.version_check.outputs.already_published == 'true'
+        run: |
+          set -euo pipefail
+          PKG_VERSION="${{ steps.version_check.outputs.version }}"
+          WORKDIR="$(mktemp -d)"
+          echo "Fetching published tarball @noorinalabs/design-system@$PKG_VERSION for comparison..."
+          if ! ( cd "$WORKDIR" && npm pack "@noorinalabs/design-system@$PKG_VERSION" \
+                   --registry=https://npm.pkg.github.com >/dev/null 2>pack.err ); then
+            echo "::warning::Could not download the published @$PKG_VERSION tarball to compare dist/ (see below). Cannot verify drift; if you changed dist/, bump the version to be safe."
+            cat "$WORKDIR/pack.err" || true
+            exit 0
+          fi
+          tar -xzf "$WORKDIR"/*.tgz -C "$WORKDIR"   # tarball extracts to ./package
+          if diff -ru "$WORKDIR/package/dist" dist >/tmp/dist-drift.diff 2>&1; then
+            echo "No dist drift — published $PKG_VERSION matches the freshly built dist. Skipping publish is safe."
+          else
+            NEXT="${PKG_VERSION%.*}.$(( ${PKG_VERSION##*.} + 1 ))"
+            echo "::error::Built dist/ differs from the already-published @noorinalabs/design-system@$PKG_VERSION, but package.json version is unchanged."
+            echo "The Publish step skips existing versions, so this change would be SILENTLY DROPPED (#111)."
+            echo "Bump the version in package.json (e.g. $NEXT) so the new dist actually ships to consumers."
+            echo "----- dist diff (published $PKG_VERSION  vs  freshly built) -----"
+            cat /tmp/dist-drift.diff
+            exit 1
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noorinalabs/design-system",
-  "version": "0.0.5-wave4.0",
+  "version": "0.0.5-wave4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noorinalabs/design-system",
-      "version": "0.0.5-wave4.0",
+      "version": "0.0.5-wave4.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noorinalabs/design-system",
-  "version": "0.0.5-wave4.0",
+  "version": "0.0.5-wave4.1",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
Closes #111

## Problem
DS PR #107 ("compile `@theme` tokens to plain `:root` CSS vars in dist", the fix for #104) merged but **never reached any version consumers install**:
- #107 carried no `package.json` version bump.
- `publish.yml` skips a version already on the registry (`already_published == 'false'` gate), so re-publishing `0.0.5-wave4.0` silently no-op'd.
- Net: the `:root` token dist sat in the build but never shipped — `main(0.0.2)` ⧸ consumed(`0.0.5-wave4.0`) divergence, and any future dist-only change without a bump would vanish the same way behind green CI.

## Fix
1. **Version bump `0.0.5-wave4.0` → `0.0.5-wave4.1`** (`package.json` + `package-lock.json`, via `npm version --no-git-tag-version`). The wave-5 build already emits `:root` correctly, so the bump is what lets that build actually publish (the version-existing guard requires it). Keeps the consumed wave-tag scheme; the `main=0.0.2` line reconciles to the wave-tag scheme structurally when wave-5 merges to main.
2. **`publish.yml` drift guard** — new step `Guard — dist drift at unchanged version (#111)` runs when the version already exists: downloads the published tarball, diffs its `dist/` against the freshly built `dist/`. **Drift → fail loudly** with a bump hint; **identical → skip is genuinely safe**. Closes the silent-drop hazard.

`dist` `:root` presence stays enforced by the existing `validate-package` CI gate (#104) — not duplicated here.

## Test Plan
Local, on the wave-5 build:

**Built dist after `npm run build` (version 0.0.5-wave4.1):**
```
no raw @theme in dist:      OK   (would be ignored by non-Tailwind consumers)
--color-border emitted:     OK
:root present:              OK   (8 :root blocks: colors + light/dark + typography/spacing/border/container/shadows)
[data-theme=dark], [data-theme=light]: both present
```
This is exactly #104's intent — base tokens apply for ANY CSS consumer (incl. the Astro landing-page / pre-mount FOUC), not only when `data-theme` is set.

**Quality gates (all green):**
- `actionlint .github/workflows/publish.yml` (shellcheck on PATH) → 0
- `npm run format:check` → pass · `npm run lint` → 0 errors (3 pre-existing react-refresh warnings) · `npm run typecheck` → 0
- `npm run test` → 84 passed (10 files)
- `python3 scripts/pre_commit_ci_sync.py .` → "config mirrors all CI-enforced checks"

**Guard behavior (by construction):** before this bump, the guard run against the still-`0.0.5-wave4.0` build would detect `dist` drift (published lacks `:root`) and fail — forcing the bump. After bump to `wave4.1`, `npm view wave4.1` → not found → `already_published=false` → guard skipped → publishes. A transient `npm pack` failure degrades to a loud `::warning::` (publish is skipped anyway when already-published), not a hard pipeline block.

## Follow-up (out of scope, not in this PR)
- Consumers (isnad-graph frontend, landing-page) bump their pin to `^0.0.5-wave4.1` + regen lockfile, then re-verify computed styles resolve from `:root`.
- Actual npm publish is an owner-gated release action — this PR delivers the bump + guard + built-dist proof only.

## Reviewers
- **Keanu Tama** (primary)
- **Luciana Ferreyra** (2nd)
Both approvals required.
