### PR TITLE
tech-debt(ci): add ./icons + ./icons/paths to validate-package-exports criticalExports (#108)

### DIFF
--- a/scripts/validate-package-exports.mjs
+++ b/scripts/validate-package-exports.mjs
@@ -17,7 +17,7 @@ let failures = 0
 let warnings = 0
 
 // Exports that are critical for consumers — failure here blocks CI
-const criticalExports = new Set(['.', './styles', './styles.css'])
+const criticalExports = new Set(['.', './icons', './icons/paths', './styles', './styles.css'])
 
 function check(label, filePath) {
   const full = resolve(root, filePath)


### PR DESCRIPTION
## Summary
Adds `./icons` and `./icons/paths` to the `criticalExports` set in `scripts/validate-package-exports.mjs` so the package-exports gate FAILs CI (instead of WARN) when either icon subpath is missing or broken.

Background: the `./icons` and `./icons/paths` subpaths were introduced in ds#103/PR #106, but the validator only treated `.`, `./styles`, and `./styles.css` as critical. A missing icon export resolved to WARN, so a green `validate-package` run was not machine-proof that the icon-path subpaths emit. (Keanu, PR #106 review note.)

## Change
```diff
-const criticalExports = new Set(['.', './styles', './styles.css'])
+const criticalExports = new Set(['.', './icons', './icons/paths', './styles', './styles.css'])
```

## Verification (local, post-build)
- **Pass run** (all dist present): all icon subpaths report `OK`, exit 0.
- **Negative run** (removed `dist/icons/index.js`): `./icons [import]` now reports **`FAIL ... (file not found)` → `1 critical export(s) failed validation` → exit 1** (previously this would have been a WARN).
- `npm run check` green: ESLint clean, `tsc --noEmit` clean, 84/84 Vitest tests pass. `prettier --check` clean.

## Reviewers
@KeanuTama (raised the note in PR #106) and @LucianaFerreyra (QA).

Closes #108
