### PR TITLE
tech-debt(a11y): set color-scheme in prefers-dark :root block (#109)

### DIFF
--- a/src/__tests__/dist-tokens.test.ts
+++ b/src/__tests__/dist-tokens.test.ts
@@ -49,4 +49,19 @@ describe.skipIf(!distBuilt)('published dist token resolution (#104)', () => {
     expect(css).toContain('[data-theme=dark]')
     expect(css).toContain('[data-theme=light]')
   })
+
+  it('sets color-scheme in the prefers-dark :root block so native UI honors dark (#109)', () => {
+    // Find the @media(prefers-color-scheme:dark){:root{...}} block that carries
+    // the color tokens (a second prefers-dark block exists for shadows) and
+    // assert it declares `color-scheme: dark` — otherwise native form controls /
+    // scrollbars stay light under OS dark for plain-CSS consumers.
+    const prefersDarkRootBodies = [
+      ...css.matchAll(/@media[^{]*prefers-color-scheme:\s*dark[^{]*\{\s*:root\s*\{([^}]*)\}/g),
+    ].map((m) => m[1] ?? '')
+    const colorTokenBlock = prefersDarkRootBodies.find((body) =>
+      body.includes('--color-background'),
+    )
+    expect(colorTokenBlock, 'prefers-dark :root color block must exist in dist').toBeDefined()
+    expect(colorTokenBlock).toMatch(/color-scheme:\s*dark/)
+  })
 })

--- a/src/tokens/colors.css
+++ b/src/tokens/colors.css
@@ -192,6 +192,7 @@
     --color-viz-categorical-9: oklch(0.72 0.14 345);
     --color-viz-categorical-10: oklch(0.68 0.15 15);
     --color-viz-accent: oklch(0.7 0.15 255);
+    color-scheme: dark;
   }
 }
 


### PR DESCRIPTION
## Summary

Sets `color-scheme: dark` in the `@media (prefers-color-scheme: dark) { :root { … } }` block of `src/tokens/colors.css`, closing an a11y gap surfaced during the ds#104 / PR #107 review.

Before this change the published dist shipped dark **token values** under OS (auto) dark mode, but only declared `color-scheme: dark` in the `[data-theme=dark]` JS-toggle override. So for plain-CSS consumers under auto dark, native UA UI — form controls, scrollbars, spinners — kept rendering in light, against the dark surface. Adding `color-scheme: dark` to the prefers-dark `:root` (mirroring the existing `[data-theme=dark]` declaration) makes the UA honor dark for native UI too.

## Changes

- `src/tokens/colors.css` — add `color-scheme: dark;` to the prefers-dark `:root` block.
- `src/__tests__/dist-tokens.test.ts` — regression assertion that the built dist's prefers-dark color `:root` block declares `color-scheme: dark` (runs against the built artifact, like the sibling #104 resolution guards).

## Verification

- `npm run check` green: lint 0 errors (3 pre-existing `react-refresh` warnings), typecheck clean, 85 tests pass.
- Confirmed in the built `dist/styles.css`: `@media(prefers-color-scheme:dark){:root{…color-scheme:dark}}`.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
