### PR TITLE
feat(motion): promote .reveal + [data-parallax] into framework-neutral DS CSS primitives (#110)

### DIFF
--- a/docs/usage/styles.md
+++ b/docs/usage/styles.md
@@ -15,7 +15,8 @@ This single import loads:
 3. **Utility classes** — text helpers, layout, links, Arabic/RTL support
 4. **Component classes** — tables, cards, badges, buttons, forms, pagination
 5. **Animations** — skeleton loading shimmer
-6. **State patterns** — loading, empty, and error page styles
+6. **Motion primitives** — framework-neutral scroll-reveal + parallax classes
+7. **State patterns** — loading, empty, and error page styles
 
 ---
 
@@ -183,6 +184,38 @@ Domain variants: `.badge-sunni`, `.badge-shia`, `.badge-sahih`, `.badge-other-gr
 | `.skeleton-row` | 2.5rem | Table/list row placeholder |
 
 Automatically disables animation when `prefers-reduced-motion: reduce` is active.
+
+---
+
+## Motion Primitives
+
+Framework-neutral scroll-reveal and parallax classes, shipped as plain compiled
+CSS (no React, no Tailwind required) so any consumer — the Astro landing page or
+the React isnad-graph app — reuses the same behaviour. The timing is built
+entirely on the DS motion tokens (`--duration-*`, `--ease-*`).
+
+The DS owns the **styling**; the consumer supplies a small, framework-neutral
+**script** that toggles the contract classes/variables:
+
+| Hook | Owner | Description |
+|------|-------|-------------|
+| `<html class="motion-ready">` | script | Added only after the script confirms motion is allowed & supported. Until present, content is fully visible (no-JS / reduced-motion safe). |
+| `.reveal` | DS | Element that fades + rises in. Visible by default; hidden pre-reveal state applies only under `.motion-ready`. |
+| `.reveal.is-visible` | script | Toggle (e.g. via `IntersectionObserver`) to play the reveal. |
+| `.reveal-delay-1` / `-2` / `-3` | DS | Token-derived stagger delays for grouped reveals. |
+| `[data-parallax]` + `--parallax-offset` | DS / script | Drift a layer on scroll; the script sets the per-element `--parallax-offset` (px), rAF-throttled. |
+
+```html
+<!-- Reveal on scroll (script toggles .is-visible) -->
+<section class="reveal">…</section>
+<section class="reveal reveal-delay-1">…</section>
+
+<!-- Parallax layer (script sets --parallax-offset on scroll) -->
+<div data-parallax></div>
+```
+
+Under `prefers-reduced-motion: reduce`, all reveals render in their final visible
+state and parallax transforms are removed — even if `.motion-ready` is present.
 
 ---
 

--- a/src/__tests__/dist-motion.test.ts
+++ b/src/__tests__/dist-motion.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/*
+ * Published-dist motion-primitive emission guard (#110).
+ *
+ * The motion primitives (`.reveal`, `[data-parallax]` + reduced-motion gating)
+ * are promoted into the DS so framework-neutral consumers — the Astro landing
+ * page (which cannot import React) and the React isnad-graph app — reuse the
+ * same behaviour from the published `dist/styles.css` instead of re-rolling it.
+ *
+ * The failure mode this guards against (DS #104/#111/#812): a "primitive" that
+ * only exists in a Tailwind `@theme {}` block, an `@source inline` mirror, or
+ * dist JS emits 0 CSS to a non-Tailwind consumer. These are plain CSS
+ * class/attribute selectors, so they MUST appear as real rules in the built
+ * artifact. CI runs `npm run build` before `npm run test`; when the dist has not
+ * been built (bare `npm run test`), the suite skips — CI is the enforcement
+ * point.
+ */
+const distCssPath = resolve(process.cwd(), 'dist/styles.css')
+const distBuilt = existsSync(distCssPath)
+
+describe.skipIf(!distBuilt)('published dist motion primitives (#110)', () => {
+  const css = distBuilt ? readFileSync(distCssPath, 'utf8') : ''
+
+  it('emits the .reveal scroll-reveal selectors as real CSS', () => {
+    expect(css).toContain('.reveal')
+    expect(css).toContain('.is-visible')
+    // Reveal transition is built on DS motion tokens, not bespoke values.
+    expect(css).toContain('var(--duration-slower)')
+    expect(css).toContain('var(--ease-out)')
+  })
+
+  it('emits the [data-parallax] primitive as real CSS', () => {
+    expect(css).toContain('[data-parallax]')
+    expect(css).toContain('--parallax-offset')
+  })
+
+  it('gates motion behind .motion-ready (no-JS safety)', () => {
+    expect(css).toContain('.motion-ready')
+  })
+
+  it('ships the prefers-reduced-motion guard', () => {
+    expect(css).toContain('prefers-reduced-motion')
+  })
+})

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -10,4 +10,5 @@
 @import './utilities.css';
 @import './components.css';
 @import './animations.css';
+@import './motion.css';
 @import './states.css';

--- a/src/styles/motion.css
+++ b/src/styles/motion.css
@@ -1,0 +1,97 @@
+/*
+ * Motion primitives — Qalam Design System (#110)
+ * ================================================
+ * Framework-neutral scroll-reveal + parallax CSS primitives, promoted from the
+ * landing page (lp#121) so EVERY consumer reuses the same behaviour instead of
+ * re-implementing it: the Astro landing page (which cannot import React) AND the
+ * React isnad-graph app both get these from the published `dist/styles.css`.
+ *
+ * These are plain CSS class / attribute selectors — NOT Tailwind utilities — so
+ * they compile into the published `dist/styles.css` unconditionally (no
+ * content-scan, no `@source inline` mirror, no `@theme {}`). A non-Tailwind,
+ * non-React consumer gets real, browser-honored rules. (DS #104/#111/#812: a
+ * primitive that only lives in `@theme {}` or in dist JS emits 0 CSS in a
+ * framework-neutral consumer — these rules deliberately avoid that trap.)
+ *
+ * Timing is built ENTIRELY on the DS motion tokens (`--duration-*`, `--ease-*`,
+ * shipped to `:root` by the token build). No bespoke durations or easing curves
+ * live here.
+ *
+ * The CSS / JS contract (the consumer supplies a small, framework-neutral
+ * script; the DS owns the styling):
+ *   - `<html class="motion-ready">` — the consumer's script adds this ONLY after
+ *     it confirms motion is allowed and supported. Until then the pre-reveal
+ *     hidden state does not apply, so the page is fully visible with JS disabled.
+ *   - `.reveal.is-visible` — the script toggles `.is-visible` (e.g. via
+ *     IntersectionObserver) to play the reveal.
+ *   - `[data-parallax]` + `--parallax-offset` — the script sets the per-element
+ *     `--parallax-offset` (px) on scroll (rAF-throttled recommended).
+ *
+ * Accessibility / no-JS safety:
+ *   - Content is fully visible BY DEFAULT. The hidden pre-reveal state applies
+ *     ONLY under `html.motion-ready`, so with JS disabled — or when the script
+ *     bails on `prefers-reduced-motion: reduce` — every `.reveal` element renders
+ *     in its final, visible state with no transition.
+ *   - The `prefers-reduced-motion: reduce` block is a belt-and-braces guard for
+ *     the case where `.motion-ready` is ever present: it forces the visible state
+ *     and removes transitions / parallax transforms.
+ */
+
+/* ============================================================
+ * SCROLL-REVEAL — fade + rise as the element enters the viewport
+ * ============================================================ */
+
+/* Default (no-JS / reduced-motion / pre-script): fully visible, no transform. */
+.reveal {
+  opacity: 1;
+  transform: none;
+}
+
+html.motion-ready .reveal {
+  opacity: 0;
+  transform: translateY(1.5rem);
+  transition:
+    opacity var(--duration-slower) var(--ease-out),
+    transform var(--duration-slower) var(--ease-out);
+}
+
+html.motion-ready .reveal.is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+/* Stagger helpers — small, DS-token-derived delays for grouped reveals. */
+html.motion-ready .reveal-delay-1 {
+  transition-delay: var(--duration-fast);
+}
+html.motion-ready .reveal-delay-2 {
+  transition-delay: var(--duration-normal);
+}
+html.motion-ready .reveal-delay-3 {
+  transition-delay: var(--duration-slow);
+}
+
+/* ============================================================
+ * PARALLAX — decorative layers drift at a fraction of scroll
+ * The consumer's script sets `--parallax-offset` (px) per element on scroll
+ * (rAF-throttled). The transform stays GPU-friendly (translate3d only) and the
+ * rule is inert until the script upgrades <html> to `.motion-ready`.
+ * ============================================================ */
+html.motion-ready [data-parallax] {
+  transform: translate3d(0, var(--parallax-offset, 0), 0);
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  html.motion-ready .reveal,
+  html.motion-ready .reveal.is-visible {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  html.motion-ready [data-parallax] {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

Promotes the scroll-reveal (`.reveal`) and parallax (`[data-parallax]`) motion **primitives** from the landing page (lp#121) into the design system as **framework-neutral, compiled CSS**, so BOTH the Astro landing page (which can't import React) AND the React isnad-graph app reuse the same behaviour from the published `dist/styles.css` instead of re-implementing it.

Closes #110. Refs lp#121, ds#102/#103/#104.

## What landed

- **`src/styles/motion.css`** — `.reveal` (+ `.reveal-delay-1/2/3` stagger helpers), `[data-parallax]`, and the `prefers-reduced-motion` gating. Timing is built **entirely on the DS motion tokens** (`--duration-*`, `--ease-*`) — no bespoke durations or curves.
- Wired into the styles barrel `src/styles/index.css`.
- **`src/__tests__/dist-motion.test.ts`** — emission guard asserting the primitives appear as real rules in the **built** `dist/styles.css` (runs against the artifact, mirroring the #104 dist-tokens guard).
- **`docs/usage/styles.md`** — new "Motion Primitives" section documenting the DS-owns-styling / consumer-owns-script contract.

## Why these emit real CSS (the no-op trap)

Per DS #104/#111/#812, a "primitive" that only lives in a Tailwind `@theme {}` block, an `@source inline` mirror, or dist JS emits **0 CSS** to a framework-neutral consumer. These are plain CSS class/attribute selectors in a barrel-imported stylesheet (like the existing `.skeleton`), so they compile into `dist/styles.css` **unconditionally** — no content-scan, no React, no Tailwind required.

## The CSS / JS contract

The DS owns the **styling**; the consumer supplies a small framework-neutral **script** that toggles:
- `<html class="motion-ready">` — added only after the script confirms motion is allowed/supported (no-JS + reduced-motion safe: content is fully visible by default).
- `.reveal.is-visible` — toggled (e.g. via `IntersectionObserver`) to play the reveal.
- `[data-parallax]` + `--parallax-offset` (px) — set per-element on scroll (rAF-throttled).

## Proof (built `dist/styles.css`)

```
.reveal{opacity:1;transform:none}
html.motion-ready .reveal{opacity:0;transform:translateY(1.5rem);transition:opacity var(--duration-slower) var(--ease-out),transform var(--duration-slower) var(--ease-out)}
html.motion-ready .reveal.is-visible{opacity:1;transform:none}
html.motion-ready [data-parallax]{transform:translate3d(0,var(--parallax-offset, 0),0);will-change:transform}
@media(prefers-reduced-motion:reduce){.reveal,html.motion-ready .reveal,...{...transition:none}html.motion-ready [data-parallax]{transform:none}}
```

## Local checks (green-before-push)

- `npm run build` — OK (`dist/styles.css` 26.37 kB)
- `npm run test` — 88 passed (incl. 4 new dist-motion tests)
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (3 pre-existing `react-refresh` warnings, unrelated)
- `npm run format:check` — clean

## Follow-up (out of scope)

The framework-neutral **JS helper** (IntersectionObserver + rAF parallax) stays per-consumer for now; a vanilla DS helper could be a future enhancement. This PR delivers the CSS primitive layer the #110 acceptance item names.

## Reviewers

@ Keanu Tama (architect) and @ Beren Yildiz (UX lead).
