### PR TITLE
build(styles): ship compiled component-utilities CSS layer (#115)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,17 @@ jobs:
           grep -q ':root' dist/styles.css || (echo "FAIL: no :root selector in dist (#104)" && exit 1)
           echo "Base tokens compiled to :root — verified (#104)"
 
+      - name: Verify component utilities compiled into dist — ds#115
+        run: |
+          # The interactive components express their structural contract as Tailwind
+          # utility classes. These must be compiled into the published dist so
+          # consumers get them without hand-mirroring via `@source inline(...)`.
+          grep -q '@layer utilities{' dist/styles.css || (echo "FAIL: utilities layer missing from dist (ds#115)" && exit 1)
+          grep -Fq '.fixed{' dist/styles.css || (echo "FAIL: Dialog overlay/content utilities not compiled into dist (ds#115)" && exit 1)
+          grep -Fq '.bg-background{background-color:var(--color-background)}' dist/styles.css \
+            || (echo "FAIL: DS-color utilities not wired to runtime tokens in dist (ds#115)" && exit 1)
+          echo "Component utilities compiled into dist — verified (ds#115)"
+
       - name: Verify exports field resolution
         run: node scripts/validate-package-exports.mjs
 

--- a/docs/usage/styles.md
+++ b/docs/usage/styles.md
@@ -16,6 +16,52 @@ This single import loads:
 4. **Component classes** — tables, cards, badges, buttons, forms, pagination
 5. **Animations** — skeleton loading shimmer
 6. **State patterns** — loading, empty, and error page styles
+7. **Compiled component-utilities layer** — the Tailwind utility classes the React
+   components depend on (Dialog positioning/overlay, focus rings, surface colors, …)
+
+---
+
+## Component-Utilities Layer (no more `@source inline` mirrors)
+
+The React components (Dialog, DropdownMenu, Select, Toast, Tooltip, …) express
+their structural contract — positioning, sizing, overlay, focus ring, surface
+colors — as Tailwind utility classes in their `className` strings (e.g. the
+Dialog overlay's `fixed inset-0 z-50 bg-black/80` and content's
+`fixed start-1/2 top-1/2 max-w-lg -translate-x-1/2 -translate-y-1/2`).
+
+Those utilities only exist once a Tailwind build *scans the component source and
+emits them*. A consuming app's Tailwind build skips `node_modules`, so it never
+generates them — which is why apps previously had to hand-mirror the class list
+with `@source inline(...)` in their own theme CSS (fragile: it silently drifts
+whenever a component's classes change).
+
+**This is no longer necessary.** The design system now runs a Tailwind utility
+pass over its own components at build time and ships the result inside
+`dist/styles.css` (in the `utilities` cascade layer, with color utilities wired
+to the runtime `--color-*` tokens). Importing the stylesheet is enough:
+
+```tsx
+import '@noorinalabs/design-system/styles.css'
+```
+
+**Consumers can — and should — delete their DS-component `@source inline(...)`
+mirrors.** For example, a block like the following in your `theme.css` can be
+removed:
+
+```css
+/* DELETE — now shipped compiled in @noorinalabs/design-system/styles.css */
+@source inline("fixed inset-0 z-50 bg-black/80");
+@source inline("fixed start-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg rounded-lg");
+/* …and the rest of the mirrored Dialog/menu/overlay class lists… */
+```
+
+Your own app's `@source` globs for *your own* markup stay as-is — only the
+mirrors that duplicated **design-system component** classes are redundant.
+
+> Note: the shipped layer covers the utilities the components actually use. The
+> open/close keyframe utilities (`animate-in`, `fade-*`, `zoom-*`) require the
+> `tailwindcss-animate` plugin and are not part of this layer; they are also not
+> required for the components to render correctly positioned and styled.
 
 ---
 

--- a/src/__tests__/dist-component-utilities.test.ts
+++ b/src/__tests__/dist-component-utilities.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/*
+ * Published-dist component-utilities guard (ds#115).
+ *
+ * The bug: the interactive components express their structural contract
+ * (positioning / sizing / overlay / focus ring / surface colors) as Tailwind
+ * utility classes in their `className` strings, but the dist build never ran a
+ * Tailwind utility pass over the components — so `dist/styles.css` shipped tokens
+ * + authored component classes but ZERO of those utilities. A consumer's
+ * Tailwind build skips `node_modules`, so the utilities emitted nowhere and apps
+ * had to hand-mirror the class list with `@source inline(...)`.
+ *
+ * styles/component-utilities.css now runs that pass, so the compiled utilities
+ * ride along in dist/styles.css and consumers can drop their `@source inline`
+ * mirrors. These assertions run against the *built* dist (CI runs `npm run
+ * build` before `npm run test`) so they verify the published artifact actually
+ * carries the utilities AND that each resolves to the runtime DS tokens — not
+ * mere class existence. When the dist has not been built (bare `npm run test`
+ * with no prior build) the suite skips; CI is the enforcement point.
+ */
+const distCssPath = resolve(process.cwd(), 'dist/styles.css')
+const distBuilt = existsSync(distCssPath)
+
+describe.skipIf(!distBuilt)('published dist component utilities (ds#115)', () => {
+  const css = distBuilt ? readFileSync(distCssPath, 'utf8') : ''
+
+  it('emits the Dialog overlay/content structural utilities', () => {
+    // The exact class contract isnad-graph previously mirrored with @source inline.
+    for (const rule of [
+      '.fixed{',
+      '.inset-0{',
+      '.z-50{',
+      '.max-w-lg{',
+      '.-translate-x-1\\/2{',
+      '.-translate-y-1\\/2{',
+      '.grid{',
+      '.rounded-lg{',
+      '.shadow-lg{',
+    ]) {
+      expect(css, `${rule} must be compiled into dist/styles.css`).toContain(rule)
+    }
+  })
+
+  it('emits DS-color utilities that resolve to the runtime --color-* tokens', () => {
+    // Color utilities must reference the tokens shipped in tokens/colors.css,
+    // not re-declare them — i.e. @theme inline, single source of truth.
+    expect(css).toContain('.bg-background{background-color:var(--color-background)}')
+    expect(css).toContain('.text-muted-foreground{color:var(--color-muted-foreground)}')
+    expect(css).toContain('.bg-popover{background-color:var(--color-popover)}')
+    // accent / ring are only used in variant form (hover/focus/data-state).
+    expect(css).toContain('bg-accent:hover{background-color:var(--color-accent)}')
+    expect(css).toContain('outline-ring:focus{outline-color:var(--color-ring)}')
+  })
+
+  it('wraps the generated utilities in the `utilities` cascade layer', () => {
+    // Layering keeps DS utilities at the same low precedence as a consumer's own
+    // Tailwind utilities, preserving override semantics.
+    expect(css).toContain('@layer utilities{')
+  })
+})

--- a/src/styles/component-utilities.css
+++ b/src/styles/component-utilities.css
@@ -1,0 +1,144 @@
+/*
+ * Compiled Component-Utilities Layer — Qalam Design System
+ * =========================================================
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The interactive components (Dialog, DropdownMenu, Select, Toast, Tooltip,
+ * Button, Badge, Input, …) express their structural contract — positioning,
+ * sizing, overlay, focus ring, surface colors — as Tailwind *utility* classes
+ * in their `className` strings (e.g. the Dialog overlay's
+ * `fixed inset-0 z-50 bg-black/80` and content's
+ * `fixed start-1/2 top-1/2 max-w-lg -translate-x-1/2 -translate-y-1/2`).
+ *
+ * Those utilities are NOT plain authored CSS — they only exist once a Tailwind
+ * build *scans the component source and emits them*. The published library
+ * historically shipped compiled JS + token CSS but never ran a Tailwind utility
+ * pass over its own components, so `dist/styles.css` contained ZERO of these
+ * utilities. A consumer's Tailwind build skips `node_modules`, so the component
+ * utilities emitted nowhere → DS dialogs/menus rendered unconstrained unless the
+ * app hand-mirrored the class list with `@source inline(...)` (fragile; drifts
+ * whenever a component changes). See ds#115 / isnad-graph #1027 (PR #1055).
+ *
+ * THE FIX
+ * -------
+ * Run a Tailwind utility pass over the component source at DS build time and
+ * ship the result. This file is that pass; it is imported into the dist style
+ * bundle (`styles/index.css`), so `dist/styles.css` now carries the compiled
+ * component-utilities layer and consumers can DROP their `@source inline`
+ * mirrors — importing `@noorinalabs/design-system/styles` is enough.
+ *
+ * DESIGN NOTES
+ * ------------
+ * - `source(none)` on the utilities import disables Tailwind's automatic
+ *   content detection; the explicit `@source` below scopes scanning to the
+ *   component implementations (stories are excluded — they are demo-only).
+ * - We import `tailwindcss/theme.css` (not the full `tailwindcss`) so we get the
+ *   default scale tokens (spacing base, radius, font-size, shadow, container)
+ *   the structural utilities resolve against, but NOT Preflight — a library must
+ *   never inject a global reset into its consumers. Tailwind v4 only emits the
+ *   theme variables actually referenced by the generated utilities, so this does
+ *   not bloat the bundle with the full default palette.
+ * - Colors are mapped with `@theme inline`: the generated color utilities
+ *   (`bg-background`, `text-muted-foreground`, …) reference the runtime
+ *   `--color-*` tokens shipped in `tokens/colors.css` rather than re-emitting
+ *   them, so there is a single source of truth for the palette and (per #104)
+ *   no `@theme` literal survives into dist.
+ */
+
+/*
+ * Declare the layer order up front so the generated utilities sit in the
+ * standard `utilities` cascade layer. This keeps DS-shipped utilities at the
+ * same (low) precedence as a consumer's own Tailwind `utilities` layer — they
+ * merge into one layer, so the consumer can still override component utilities,
+ * and authored DS component classes (not in any layer) continue to win over them.
+ */
+@layer theme, utilities;
+
+@import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/utilities.css' layer(utilities) source(none);
+
+/* Scan the component implementations only (not stories/tests). */
+@source '../components/*.tsx';
+@source not '../components/*.stories.tsx';
+
+/*
+ * Map the Qalam palette into Tailwind's color namespace *inline* so color
+ * utilities resolve to the runtime tokens from tokens/colors.css. `inline`
+ * means the value is substituted into the utility (e.g.
+ * `.bg-background{background-color:var(--color-background)}`) and the token is
+ * NOT re-declared here — tokens/colors.css remains the single source of truth.
+ */
+@theme inline {
+  --color-primary: var(--color-primary);
+  --color-primary-hover: var(--color-primary-hover);
+  --color-primary-foreground: var(--color-primary-foreground);
+  --color-secondary: var(--color-secondary);
+  --color-secondary-foreground: var(--color-secondary-foreground);
+  --color-muted: var(--color-muted);
+  --color-muted-foreground: var(--color-muted-foreground);
+  --color-accent: var(--color-accent);
+  --color-accent-foreground: var(--color-accent-foreground);
+  --color-destructive: var(--color-destructive);
+  --color-destructive-foreground: var(--color-destructive-foreground);
+  --color-success: var(--color-success);
+  --color-success-foreground: var(--color-success-foreground);
+  --color-warning: var(--color-warning);
+  --color-warning-foreground: var(--color-warning-foreground);
+  --color-info: var(--color-info);
+  --color-info-foreground: var(--color-info-foreground);
+
+  --color-background: var(--color-background);
+  --color-foreground: var(--color-foreground);
+  --color-card: var(--color-card);
+  --color-card-foreground: var(--color-card-foreground);
+  --color-popover: var(--color-popover);
+  --color-popover-foreground: var(--color-popover-foreground);
+
+  --color-border: var(--color-border);
+  --color-input: var(--color-input);
+  --color-ring: var(--color-ring);
+
+  --color-brand-navy: var(--color-brand-navy);
+  --color-brand-navy-light: var(--color-brand-navy-light);
+  --color-brand-navy-dark: var(--color-brand-navy-dark);
+  --color-brand-gold: var(--color-brand-gold);
+  --color-brand-gold-light: var(--color-brand-gold-light);
+  --color-brand-gold-dark: var(--color-brand-gold-dark);
+
+  --color-sahih: var(--color-sahih);
+  --color-sahih-bg: var(--color-sahih-bg);
+  --color-hasan: var(--color-hasan);
+  --color-hasan-bg: var(--color-hasan-bg);
+  --color-daif: var(--color-daif);
+  --color-daif-bg: var(--color-daif-bg);
+  --color-mawdu: var(--color-mawdu);
+  --color-mawdu-bg: var(--color-mawdu-bg);
+
+  --color-sunni: var(--color-sunni);
+  --color-sunni-bg: var(--color-sunni-bg);
+  --color-shia: var(--color-shia);
+  --color-shia-bg: var(--color-shia-bg);
+
+  --color-tier-thiqah: var(--color-tier-thiqah);
+  --color-tier-thiqah-bg: var(--color-tier-thiqah-bg);
+  --color-tier-saduq: var(--color-tier-saduq);
+  --color-tier-saduq-bg: var(--color-tier-saduq-bg);
+  --color-tier-daif-narrator: var(--color-tier-daif-narrator);
+  --color-tier-daif-narrator-bg: var(--color-tier-daif-narrator-bg);
+  --color-tier-matruk: var(--color-tier-matruk);
+  --color-tier-matruk-bg: var(--color-tier-matruk-bg);
+  --color-tier-kadhdhab: var(--color-tier-kadhdhab);
+  --color-tier-kadhdhab-bg: var(--color-tier-kadhdhab-bg);
+
+  --color-viz-categorical-1: var(--color-viz-categorical-1);
+  --color-viz-categorical-2: var(--color-viz-categorical-2);
+  --color-viz-categorical-3: var(--color-viz-categorical-3);
+  --color-viz-categorical-4: var(--color-viz-categorical-4);
+  --color-viz-categorical-5: var(--color-viz-categorical-5);
+  --color-viz-categorical-6: var(--color-viz-categorical-6);
+  --color-viz-categorical-7: var(--color-viz-categorical-7);
+  --color-viz-categorical-8: var(--color-viz-categorical-8);
+  --color-viz-categorical-9: var(--color-viz-categorical-9);
+  --color-viz-categorical-10: var(--color-viz-categorical-10);
+  --color-viz-accent: var(--color-viz-accent);
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -11,3 +11,11 @@
 @import './components.css';
 @import './animations.css';
 @import './states.css';
+
+/*
+ * Compiled component-utilities layer (ds#115): emits the Tailwind utility
+ * classes the interactive components rely on so consumers get them from
+ * dist/styles.css instead of hand-mirroring with `@source inline(...)`.
+ * Imported last so the utility layer is appended after the authored rules.
+ */
+@import './component-utilities.css';


### PR DESCRIPTION
## Summary
Ships a **compiled component-utilities CSS layer** in `dist/styles.css` so consuming apps get the Tailwind utility classes the interactive components depend on — and can **drop their `@source inline(...)` mirrors**. Fixes ds#115.

## The bug
The components (Dialog, DropdownMenu, Select, Toast, Tooltip, …) express their structural contract — positioning, sizing, overlay, focus ring, surface colors — as Tailwind utility classes in their `className` strings (e.g. the Dialog overlay's `fixed inset-0 z-50 bg-black/80`, content's `fixed start-1/2 top-1/2 max-w-lg -translate-x-1/2 -translate-y-1/2`). Those utilities only exist once a Tailwind build *scans the component source and emits them*. The dist build never ran a utility pass over its own components, so `dist/styles.css` shipped tokens + authored component classes but **zero** of these utilities. A consumer's Tailwind build skips `node_modules`, so they emitted nowhere → DS dialogs rendered unconstrained unless the app hand-mirrored the class list with `@source inline(...)` (fragile; drifts on every component change). See isnad-graph #1027 / PR #1055.

## The fix
- New `src/styles/component-utilities.css` runs a Tailwind utility pass scoped to the component sources, imported into the dist style bundle so the compiled utilities ride along in `dist/styles.css`.
- Imports `tailwindcss/theme.css` (scale tokens) + `tailwindcss/utilities.css` with `source(none)` + explicit `@source` over `components/*.tsx` (stories excluded). **No Preflight** — a library must never inject a global reset into consumers.
- Colors mapped via `@theme inline` → color utilities reference the runtime `--color-*` tokens (single source of truth; no `@theme` literal in dist, preserving the #104 guarantee).
- Utilities emitted in the `utilities` cascade layer → same low precedence as a consumer's own Tailwind utilities (override semantics intact).

## Proof the layer contains the utilities
Built `dist/styles.css` now contains, inside `@layer utilities{…}`:
```
.fixed{position:fixed}  .inset-0{inset:calc(var(--spacing)*0)}  .z-50{z-index:50}
.max-w-lg{max-width:var(--container-lg)}  .-translate-x-1/2{…}  .grid{display:grid}
.rounded-lg{border-radius:var(--radius-lg)}  .shadow-lg{…}
.bg-background{background-color:var(--color-background)}
.text-muted-foreground{color:var(--color-muted-foreground)}
.bg-popover{background-color:var(--color-popover)}
…:hover/.…[data-state=open]{background-color:var(--color-accent)}   (bg-accent variants)
….outline-ring:focus{outline-color:var(--color-ring)}
```
No `@theme` literal leaks; no default Tailwind palette bloat (25.6 kB → 46.0 kB, gzip 4.0 → 7.8 kB).

## Consumer migration
`docs/usage/styles.md` documents that consumers can delete their DS-component `@source inline(...)` mirrors — importing `@noorinalabs/design-system/styles.css` is now enough. (isnad-graph's `theme.css` mirror removal is a separate consumer-side PR.)

## Regression guards
- `src/__tests__/dist-component-utilities.test.ts` — runs against the built dist (CI builds before test), asserts the structural + color utilities are present and resolve to the runtime tokens.
- Packaging-job CI step `Verify component utilities compiled into dist — ds#115`, mirroring the existing #104 check.

## CI status (local, full parity)
build ✓ · lint ✓ (3 pre-existing warnings, untouched files) · typecheck ✓ · test ✓ (87 passed) · prettier ✓ · actionlint ✓ · markdownlint ✓ · cspell ✓ · sync-drift gate ✓

## Note
The open/close keyframe utilities (`animate-in`, `fade-*`, `zoom-*`) require the `tailwindcss-animate` plugin and are out of scope — they were never compiled before this PR either and are not needed for correct positioning/styling.

Closes #115

Reviewers: @Keanu Tama, @Maricel Reyes
