### PR TITLE
fix(release): bump version for wave-5 dist changes — clear #111 drift guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noorinalabs/design-system",
-  "version": "0.0.5-wave4.1",
+  "version": "0.0.5-wave5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noorinalabs/design-system",
-      "version": "0.0.5-wave4.1",
+      "version": "0.0.5-wave5.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noorinalabs/design-system",
-  "version": "0.0.5-wave4.1",
+  "version": "0.0.5-wave5.0",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
## Problem

The wave-5 branch (`deployments/phase-5/wave-5`) shipped `dist/` changes via #118 (motion primitives) and #119 (compiled utilities CSS), but `package.json` still carried the prior wave's `0.0.5-wave4.1` — a version that is **already published** to GitHub Packages.

`publish.yml`'s **"Guard — dist drift at unchanged version (#111)"** step therefore fails on the wave branch: it fetches the published `0.0.5-wave4.1` tarball, diffs its `dist/` against the freshly built `dist/`, sees they differ, and errors. The Publish step skips versions that already exist, so without this guard the wave-5 dist would be **silently dropped** (the exact regression #111 was created to catch — see #107's lost `:root` token fix). This RED publish run blocks the wave→main merge (#120).

## Fix

Bump the version to `0.0.5-wave5.0`, following the `CONTRIBUTING.md` **"Wave-branch pre-releases"** convention:

- Format `<X.Y.Z>-wave<N>.<patch>` — `<N>` is the wave number (**5** for `deployments/phase-5/wave-5`), `<patch>` starts at **0** for the first re-cut on the wave branch.
- The new version is **unpublished**, so `version_check.already_published` is `false`, the drift guard is skipped entirely, and the Publish step ships the wave-5 dist to consumers.

`package-lock.json` is synced to the new version so `npm ci` stays green.

## Verification

- `npm ci` — clean (lockfile in sync)
- `npm run check` (lint + typecheck + test) — 81 passed, 11 skipped
- `npm run build` — clean

## Notes

`dist/` is gitignored and built fresh in CI, so this diff is package.json + package-lock.json only (no committed dist). The version string is not embedded in dist artifacts; the published-tarball drift comes from the real #118/#119 content, not the version.

TechDebt: none.

Refs #111 (the guard is working as designed — this clears the recurrence it caught)

🤖 Generated with [Claude Code](https://claude.com/claude-code)