### PR TITLE
docs(README): document required pre-commit + pre-push hook install (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ npm run build:storybook  # Build static Storybook site
 npm run check            # Run lint + typecheck + tests
 ```
 
+### Git hooks (required)
+
+This repo mirrors its CI checks locally via [pre-commit](https://pre-commit.com/). After cloning, install BOTH hook stages once:
+
+```bash
+pre-commit install                       # commit-stage checks
+pre-commit install --hook-type pre-push  # push-stage checks
+```
+
+- **Commit stage** runs: gitleaks (secret scan), actionlint (workflow lint), prettier (`format:check`), and eslint — the fast checks that catch the most common defects before a commit is recorded.
+- **Pre-push stage** runs: typecheck (`tsc`), build, and the Vitest test suite — the heavier compile + test surface, run before code leaves the machine.
+
+These mirror `.github/workflows/ci.yml` (and the docs/config gates in `.github/workflows/docs.yml`) so failures surface locally before a PR (org-wide local⇄CI parity, noorinalabs-main#684). Never bypass with `--no-verify`. If `pre-commit install` "cowardly refuses" because `core.hooksPath` is set, run `git config --unset core.hooksPath` first.
+
 ## Documentation
 
 - [Usage & Installation](docs/usage/README.md)


### PR DESCRIPTION
## Summary

Documents the required two-stage local git hook install in the repo `README.md`, closing the gap where the README listed dev commands but not the `pre-commit` / `pre-push` hook setup.

A new **"Git hooks (required)"** subsection under **Development** covers:

- The one-time install of BOTH hook stages (`pre-commit install` + `pre-commit install --hook-type pre-push`).
- The REAL per-stage hooks, read from `.pre-commit-config.yaml` + `.github/workflows/ci.yml`/`docs.yml` at HEAD:
  - **Commit stage:** gitleaks, actionlint, prettier (`format:check`), eslint.
  - **Pre-push stage:** typecheck (`tsc`), build, Vitest test suite.
- The org-wide local⇄CI parity mandate (noorinalabs-main#684), the no-`--no-verify` rule, and the `core.hooksPath` unset fix for pre-commit's "cowardly refuses" case.

Docs-only change; no source/behavior impact.

## Verification

- `cspell` (docs.yml gate): 0 issues over README.md
- `markdownlint-cli2` (docs.yml gate): 0 errors
- Commit-stage hooks (gitleaks/actionlint/prettier/eslint) and pre-push hooks (typecheck/build/test) all passed locally on commit + push.

Closes #122

> Needs 2 reviewers per charter.
