### PR TITLE
docs(claude): add per-repo zsh shell-environment note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ npm run test:ui     # Run Vitest with UI
 npm run check       # Run all checks (lint + typecheck + test)
 ```
 
+### Shell environment
+
+The development shell is **zsh** (not bash). Write zsh-safe terminal commands and avoid bash-only idioms (`declare -A`, `${!arr[@]}`, unquoted `?`/`*` globs such as `…?ref=main` URLs). Prefer POSIX-portable constructs; use `bash -c '...'` explicitly when bash is genuinely required. Canonical do/don't list: org `docs/TOOLCHAIN.md` "Shell environment" section + `ontology/conventions.md` in noorinalabs-main.
+
 ## Code Conventions
 
 - All components use **CVA** for variant definitions — no inline conditional class logic


### PR DESCRIPTION
Adds a concise **Shell environment** subsection to this repo's `CLAUDE.md`, noting that the development shell is **zsh** (not bash) and that contributors/agents should avoid bash-only idioms (`declare -A`, `${!arr[@]}`, unquoted `?`/`*` globs). It points at the canonical do/don't list in the org `docs/TOOLCHAIN.md` "Shell environment" section + `ontology/conventions.md` in noorinalabs-main.

Minimal, doc-only change — no restructuring.

Part of #759