### PR TITLE
tech-debt(ci-parity): full cspell local⇄CI parity — mirror + classified sync-gate kind (rollout of main#684)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -202,9 +202,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Drift-gate unit tests
+        # The gate's kind-classifier is the load-bearing logic — if it stops
+        # recognizing a kind (e.g. the `cspell` classification added for
+        # noorinalabs-main#684) the gate would silently pass on real drift. Run
+        # its stdlib-unittest suite so a regression in the classifier fails CI
+        # here rather than going unnoticed.
+        run: python3 -m unittest discover -s scripts/tests -v
       - name: Verify pre-commit config mirrors CI-enforced checks (#327)
         # Fails if a check CI enforces (eslint/prettier/typecheck/build/test/
-        # actionlint/gitleaks/…) is missing from .pre-commit-config.yaml, so
-        # local hooks can't silently drift behind CI. This is the
+        # cspell/actionlint/gitleaks/…) is missing from .pre-commit-config.yaml,
+        # so local hooks can't silently drift behind CI. This is the
         # machine-enforcement that keeps the #327 mirror from rotting.
         run: python3 scripts/pre_commit_ci_sync.py .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,32 @@ repos:
         args: ["-ignore", "constant expression \"false\" in condition"]
         stages: [pre-commit]
 
+  # --- Spellcheck (commit stage) — mirrors docs.yml `spellcheck` cspell job ---
+  # A typo in authored prose should fail at commit time, not only surface as a
+  # CI red after push (rollout of noorinalabs-main#684). Pinned to v8.4.0 of
+  # cspell-cli to match the exact cspell the
+  # `streetsidesoftware/cspell-action@…v8.4.0` CI step bundles — same engine +
+  # dictionaries on both sides, so a word that passes locally passes in CI and
+  # vice-versa. `language: node`, so pre-commit provisions its own node/cspell
+  # env (no system cspell required).
+  #
+  # `files` is the regex equivalent of the CI action's authored-prose glob set
+  # (CLAUDE.md, README.md, RUNBOOK.md, docs, skills, charter); `--config
+  # .cspell.json` reuses the same dictionaries + ignore rules CI loads. New
+  # domain terms go in .cspell/project-words.txt — never bless a wrong spelling.
+  #
+  # NOTE: this repo's sync-drift gate (scripts/pre_commit_ci_sync.py) does NOT
+  # yet classify a `cspell` kind, so it cannot enforce this mirror — closing
+  # that blind spot is the org-wide follow-up tracked under noorinalabs-main#684.
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+        args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
+        files: ^(CLAUDE\.md|README\.md|RUNBOOK\.md|docs/.*\.md|\.claude/skills/.*\.md|\.claude/team/charter\.md)$
+        stages: [pre-commit]
+
   # --- Local hooks ---
   - repo: local
     hooks:

--- a/scripts/pre_commit_ci_sync.py
+++ b/scripts/pre_commit_ci_sync.py
@@ -23,7 +23,7 @@ step vs a `ruff` pre-commit `id:`). We normalize both sides to a small set of
 kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
-    terraform-fmt, gitleaks, actionlint, vitest, pip-audit, build
+    terraform-fmt, gitleaks, actionlint, vitest, pip-audit, build, cspell
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
@@ -65,6 +65,13 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "vitest": ("vitest", "npm run test", "npm test"),
     "pip-audit": ("pip-audit", "pip audit"),
     "build": ("build-and-validate", "build-and-test", "npm run build", "docker build"),
+    # `cspell` closes the spell-check blind spot (noorinalabs-main#684): docs.yml's
+    # Spellcheck job runs `streetsidesoftware/cspell-action` (a `cspell` CLI under
+    # the hood), but until this kind existed an un-classified spell gate produced
+    # ZERO drift signal — so cspell could be enforced in CI with no pre-commit
+    # mirror, and new domain vocabulary failed only after push. Patterns cover the
+    # action ref, the bundled-CLI step name, and the generic job/step word.
+    "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/scripts/tests/test_pre_commit_ci_sync.py
+++ b/scripts/tests/test_pre_commit_ci_sync.py
@@ -1,0 +1,134 @@
+"""Tests for pre_commit_ci_sync — the pre-commit <-> CI drift gate (#327).
+
+Verifies:
+  1. The `cspell` kind is classified on both sides so the Spellcheck job's
+     local⇄CI mirror is ENFORCED, not silently ignored (noorinalabs-main#684).
+  2. The drift direction that gates: CI-enforced-but-not-local is harmful;
+     local-but-not-CI is stricter-local (informational, never a gate fail).
+  3. This repo's real config mirrors its CI kinds (no harmful drift), with
+     cspell present on both sides.
+
+Run: `python3 -m unittest discover -s scripts/tests` (stdlib only, no deps).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Helper lives at scripts/pre_commit_ci_sync.py; this test is at
+# scripts/tests/test_*.py. parent.parent reaches the scripts/ root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pre_commit_ci_sync import (  # noqa: E402
+    check_repo,
+    compute_drift,
+    kinds_from_ci,
+    kinds_from_precommit,
+)
+
+# scripts/tests/test_*.py -> parents[2] is the repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class CspellKindClassification(unittest.TestCase):
+    """noorinalabs-main#684: the spell-check blind spot. A CI Spellcheck job must
+    classify as the `cspell` kind on EITHER expression — the
+    `streetsidesoftware/cspell-action` `uses:` ref, the bundled-CLI `cspell`
+    step/run, or the generic `spellcheck` word — and a pre-commit cspell hook
+    must classify too, so a CI spell gate with no local mirror produces harmful
+    drift instead of silence."""
+
+    def test_cspell_action_uses_ref_classified(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    name: Spellcheck (cspell)
+    steps:
+      - name: cspell
+        uses: streetsidesoftware/cspell-action@de2a73e # v8.4.0
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_cspell_cli_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  spell:
+    steps:
+      - run: npx cspell --config .cspell.json "**/*.md"
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_generic_spellcheck_word_classified(self) -> None:
+        # A repo that names the step/run with the generic word still registers.
+        self.assertIn("cspell", kinds_from_ci("      - run: make spellcheck\n"))
+
+    def test_precommit_cspell_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+"""
+        self.assertIn("cspell", kinds_from_precommit(cfg))
+
+    def test_ci_cspell_without_precommit_is_harmful_drift(self) -> None:
+        # The exact divergence #684 exists to catch: CI enforces cspell, the
+        # pre-commit config does not mirror it.
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: eslint
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("cspell", harmful)
+
+    def test_ci_cspell_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("cspell", harmful)
+
+
+class RealRepoConfig(unittest.TestCase):
+    """The actual committed config in THIS repo must have no harmful drift, and
+    cspell must be enforced on both sides (the parity this PR delivers)."""
+
+    def _wf_paths(self) -> list[Path]:
+        return sorted((_REPO_ROOT / ".github" / "workflows").glob("*.y*ml"))
+
+    def test_repo_has_no_harmful_drift(self) -> None:
+        precommit = _REPO_ROOT / ".pre-commit-config.yaml"
+        harmful, _ = check_repo(precommit, self._wf_paths())
+        self.assertEqual(harmful, set(), f"unexpected harmful drift: {sorted(harmful)}")
+
+    def test_repo_enforces_cspell_both_sides(self) -> None:
+        precommit_text = (_REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+        ci_text = "\n".join(p.read_text(encoding="utf-8") for p in self._wf_paths())
+        self.assertIn("cspell", kinds_from_precommit(precommit_text))
+        self.assertIn("cspell", kinds_from_ci(ci_text))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

**Full** cspell local⇄CI parity for **noorinalabs-design-system** — the rollout of noorinalabs-main#684 to this repo, matching the other 5 repos. Not mirror-only: both the pre-commit mirror AND the sync-drift gate's cspell classification land here, so the mirror is **enforced**, not just present.

This repo's CI cspell job lives in `docs.yml` (`spellcheck`), using `streetsidesoftware/cspell-action@…v8.4.0`.

## What changed

**1. Mirror — `.pre-commit-config.yaml`**
- Added a `streetsidesoftware/cspell-cli` commit-stage hook.
- **Pinned `rev: v8.4.0`** — matches the cspell engine bundled by the `cspell-action@…v8.4.0` CI step, so the same engine + dictionaries run on both sides.
- `--config .cspell.json` reuses the same dictionaries + ignore rules CI loads.
- `files` regex `^(CLAUDE\.md|README\.md|RUNBOOK\.md|docs/.*\.md|\.claude/skills/.*\.md|\.claude/team/charter\.md)$` is the regex equivalent of the CI action's authored-prose glob set.

**2. Gate classification — `scripts/pre_commit_ci_sync.py`**
- Added the `cspell` kind to `_KIND_PATTERNS`: `("cspell", "spellcheck", "streetsidesoftware/cspell")`, matching the parent-canonical classifier.
- Previously cspell was an **unclassified blind spot**: the sync-drift gate produced ZERO drift signal for a CI spell gate with no local mirror (exactly the gap noorinalabs-main#684 targets). Now a CI Spellcheck job without a pre-commit mirror is reported as **harmful drift**, so this parity cannot silently rot.

**3. Tests + CI enforcement**
- New `scripts/tests/test_pre_commit_ci_sync.py` (stdlib unittest): `CspellKindClassification` (action `uses:` ref, CLI `run` step, generic `spellcheck` word, pre-commit hook `id`, harmful-drift, no-drift-with-mirror) + `RealRepoConfig` (this repo's actual config has no harmful drift and enforces cspell on both sides).
- Wired the test into the existing `precommit-ci-sync` job in `docs.yml` (`python3 -m unittest discover -s scripts/tests`), so a classifier regression fails CI.

## Verification

- `python3 scripts/pre_commit_ci_sync.py .` (exactly as `docs.yml` invokes it) → **OK**: cspell enforced, no harmful drift (only `gitleaks` is stricter-local, informational).
- `python3 -m unittest discover -s scripts/tests` → **8/8 pass**.
- `pre-commit run cspell --all-files` → **Passed**; actionlint clean on the edited `docs.yml`; pre-push typecheck/build/test green on push.

Closes #128
Part of noorinalabs-main#684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2U19RpdPtzAv8qfjQwacx
